### PR TITLE
feat(sql-import): add SQL Server bootstrap for table types and columnstore procedures

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,7 +24,7 @@ sales:
   total_rows: 1152503
   chunk_size: 2000000
 
-  file_format: "parquet"          # csv | parquet | deltaparquet
+  file_format: "csv"          # csv | parquet | deltaparquet
   write_delta: true
   delta_output_folder: "./data/fact_out/delta"
 

--- a/scripts/sql/bootstrap/create_procs.sql
+++ b/scripts/sql/bootstrap/create_procs.sql
@@ -1,0 +1,58 @@
+CREATE OR ALTER PROCEDURE dbo.ManageClusteredColumnstoreIndexes
+    @Action  varchar(10),
+    @Tables  dbo.TableNameList READONLY
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @Action NOT IN ('CREATE', 'DROP')
+    BEGIN
+        THROW 50000, 'Invalid @Action. Use CREATE or DROP.', 1;
+        RETURN;
+    END;
+
+    IF NOT EXISTS (SELECT 1 FROM @Tables)
+    BEGIN
+        THROW 50001, 'No tables provided.', 1;
+        RETURN;
+    END;
+
+    DECLARE @sql nvarchar(max);
+
+    IF @Action = 'CREATE'
+    BEGIN
+        SELECT @sql = STRING_AGG(
+        N'
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = ''CCI_' + TableName + '''
+      AND object_id = OBJECT_ID(''dbo.' + TableName + ''')
+)
+BEGIN
+    CREATE CLUSTERED COLUMNSTORE INDEX CCI_' + TableName + '
+    ON dbo.' + QUOTENAME(TableName) + ';
+END;',
+        CHAR(10))
+        FROM @Tables;
+    END
+    ELSE
+    BEGIN
+        SELECT @sql = STRING_AGG(
+        N'
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = ''CCI_' + TableName + '''
+      AND object_id = OBJECT_ID(''dbo.' + TableName + ''')
+)
+BEGIN
+    DROP INDEX CCI_' + TableName + '
+    ON dbo.' + QUOTENAME(TableName) + ';
+END;',
+        CHAR(10))
+        FROM @Tables;
+    END;
+
+    EXEC sys.sp_executesql @sql;
+END;

--- a/scripts/sql/bootstrap/create_types.sql
+++ b/scripts/sql/bootstrap/create_types.sql
@@ -1,0 +1,13 @@
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.types
+    WHERE is_table_type = 1
+      AND name = 'TableNameList'
+      AND schema_id = SCHEMA_ID('dbo')
+)
+BEGIN
+    CREATE TYPE dbo.TableNameList AS TABLE
+    (
+        TableName sysname NOT NULL
+    );
+END;

--- a/scripts/sql/columnstore/create_drop_cci.sql
+++ b/scripts/sql/columnstore/create_drop_cci.sql
@@ -1,0 +1,26 @@
+/*
+Optional helper script.
+This file is NOT executed automatically by the generator.
+Run manually before/after data load if columnstore indexes are desired.
+*/
+
+-- Execution
+DECLARE @Tables dbo.TableNameList;
+
+INSERT INTO @Tables (TableName)
+VALUES
+     ('Sales')
+    ,('Customers')
+    ,('Products')
+    ,('ProductCategory')
+    ,('ProductSubcategory')
+    ,('Dates')
+    ,('Stores')
+    ,('Promotions')
+    ,('Geography')
+    ,('Currency')
+    ,('ExchangeRates')
+
+EXEC dbo.ManageClusteredColumnstoreIndexes
+    @Action = 'CREATE',
+    @Tables = @Tables;

--- a/src/engine/packaging.py
+++ b/src/engine/packaging.py
@@ -141,6 +141,14 @@ def package_output(cfg, sales_cfg, parquet_dims: Path, fact_out: Path):
 
             done("Sales fact copied (Delta snapshot).")
 
+    columnstore_sql = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "sql"
+        / "columnstore"
+        / "create_drop_cci.sql"
+    )
+
     # ============================================================
     # SQL SCRIPT GENERATION — CSV ONLY (correct & reachable)
     # ============================================================
@@ -174,6 +182,16 @@ def package_output(cfg, sales_cfg, parquet_dims: Path, fact_out: Path):
                 cfg=cfg,
                 skip_order_cols=sales_cfg.get("skip_order_cols", False),
             )
+            # ---------------------------------------------------------
+            # Copy optional Columnstore helper SQL (CSV only)
+            # ---------------------------------------------------------
+            if columnstore_sql.is_file():
+                shutil.copy2(
+                    columnstore_sql,
+                    final_folder / "create_drop_cci.sql",
+                )
+                info("Included optional create_drop_cci.sql in CSV output.")
+
     else:
         info("Skipping SQL script generation for non-CSV format.")
 


### PR DESCRIPTION
This PR introduces a SQL Server bootstrap step to support optional columnstore operations.

### What’s included
- Adds SQL bootstrap scripts for:
  - Table-valued type (`dbo.TableNameList`)
  - Stored procedure (`dbo.ManageClusteredColumnstoreIndexes`)
- Executes bootstrap scripts after tables, data, and views are created
- Runs TYPE and PROC creation outside transactions (autocommit mode)
- Keeps columnstore index creation explicit and opt-in

### What’s not included
- No clustered columnstore indexes are created automatically
- No changes to data generation logic

Closes #8