### PR TITLE
Refactor CSV SQL structure and import flow

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,10 +21,10 @@ sales:
   parquet_folder: "./data/parquet_dims"
   out_folder: "./data/fact_out"
 
-  total_rows: 501525
+  total_rows: 50152
   chunk_size: 1000000
 
-  file_format: "csv"          # csv | parquet | deltaparquet
+  file_format: "parquet"          # csv | parquet | deltaparquet
   write_delta: true
   delta_output_folder: "./data/fact_out/delta"
 

--- a/scripts/print_project_tree.py
+++ b/scripts/print_project_tree.py
@@ -5,13 +5,14 @@ EXCLUDE_DIRS = {
     "build", "dist", ".idea", ".vscode",
     ".mypy_cache", ".pytest_cache",
     "data", "generated_datasets",
-    "logs", "output", "fact_out", "parquet_dims"
+    "logs", "output", "fact_out", "parquet_dims", 
+    "PBIP Parquet", "PBIP CSV"
 }
 
 EXCLUDE_EXT = {".pyc", ".pyo", ".pyd", ".so"}
 
 # file types to display
-INCLUDE_EXT = {".py", ".ps1", ".pbix", ".pbit", '.png'}
+INCLUDE_EXT = {".py", ".ps1", ".pbix", ".pbit", '.png', ".parquet", ".sql"}
 
 def print_tree(root=".", prefix=""):
     try:
@@ -43,5 +44,13 @@ def print_tree(root=".", prefix=""):
 
 
 if __name__ == "__main__":
-    print("Project Structure:\n")
-    print_tree(".")
+    import sys
+
+    root_path = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else r"." # generated_datasets\2026-01-31 02_02_58 PM Customers 53K Sales 50K CSV
+    )
+
+    print(f"Project Structure ({os.path.abspath(root_path)}):\n")
+    print_tree(root_path)

--- a/src/engine/runners/sales_runner.py
+++ b/src/engine/runners/sales_runner.py
@@ -159,8 +159,6 @@ def run_sales_pipeline(sales_cfg, fact_out, parquet_dims, cfg):
     
     final_folder = package_output(cfg, sales_cfg, parquet_dims, fact_out)
 
-    fmt = sales_cfg["file_format"].lower()
-
     pbip_template = None
 
     if fmt == "csv":

--- a/src/tools/sql/generate_bulk_insert_sql.py
+++ b/src/tools/sql/generate_bulk_insert_sql.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 from pathlib import Path
-from src.utils.logging_utils import info, work, skip
+from src.utils.logging_utils import work, skip
 
 
 def generate_bulk_insert_script(
@@ -19,9 +19,17 @@ def generate_bulk_insert_script(
 
     csv_folder = Path(csv_folder)
 
-    # Prevent stray script in project root
-    if output_sql_file == "bulk_insert.sql":
-        output_sql_file = str(csv_folder / "_ignored_bulk_insert.sql")
+    output_sql_file = Path(output_sql_file)
+
+    # If caller provides a path, use it as the anchor
+    if output_sql_file.is_absolute():
+        load_dir = output_sql_file.parent
+    else:
+        # Fallback (legacy behavior)
+        load_dir = csv_folder.parent / "load"
+        output_sql_file = load_dir / output_sql_file
+
+    load_dir.mkdir(parents=True, exist_ok=True)
 
     # Collect CSV files
     csv_files = sorted(

--- a/src/tools/sql/generate_create_table_scripts.py
+++ b/src/tools/sql/generate_create_table_scripts.py
@@ -6,7 +6,7 @@ from src.utils.static_schemas import (
     get_sales_schema,
     get_dates_schema,
 )
-from src.utils.logging_utils import work, skip
+from src.utils.logging_utils import work
 
 
 def create_table_from_static_schema(table_name, cols):
@@ -25,10 +25,11 @@ def generate_all_create_tables(
     cfg,
     skip_order_cols=False,
 ):
-    os.makedirs(output_folder, exist_ok=True)
+    schema_dir = Path(output_folder) / "schema"
+    schema_dir.mkdir(parents=True, exist_ok=True)
 
-    dim_out_path = os.path.join(output_folder, "create_dimensions.sql")
-    fact_out_path = os.path.join(output_folder, "create_facts.sql")
+    dim_out_path  = schema_dir / "01_create_dimensions.sql"
+    fact_out_path = schema_dir / "02_create_facts.sql"
 
     dim_scripts = []
     fact_scripts = []


### PR DESCRIPTION
### Summary

This PR cleans up how SQL artifacts are generated and imported for CSV runs.

All CSV-related SQL is now grouped under a single `sql/` folder with clear separation between schema, data load, and manual helper scripts. Parquet and Delta outputs remain SQL-free.

### Changes
- Move all CSV SQL artifacts under `sql/` (`schema`, `load`, `indexes`)
- Enforce CSV-only SQL generation
- Add deterministic numbering for schema and load scripts
- Package constraints, views, and CCI helper scripts correctly
- Prevent automatic execution of index/CCI scripts
- Improve project tree utility to support arbitrary paths

### Notes
- `sql/indexes/create_drop_cci.sql` is included as a **manual helper only**
- Index scripts are never auto-executed during import

Closes #13