### PR TITLE
refactor(scripts): harden venv bootstrap/activation utilities

### DIFF
--- a/scripts/activate_venv.ps1
+++ b/scripts/activate_venv.ps1
@@ -1,10 +1,55 @@
 # ------------------------------------------------------------
 # Activate virtual environment
-# Always activates .venv from project root
-# MUST be dot-sourced
+#
+# Default behavior:
+#   - Auto-detects the project root (prefers repo markers like .git/pyproject.toml)
+#   - Activates the venv (default: .venv)
+#
+# IMPORTANT:
+#   This script MUST be dot-sourced, otherwise activation won't persist.
+#   Example:
+#     . .\scripts\activate_venv.ps1
 # ------------------------------------------------------------
 
+[CmdletBinding()]
+param(
+    [string]$VenvDir = ".venv",
+
+    # Optional override. If omitted, the script auto-detects project root.
+    [string]$ProjectRoot,
+
+    # If the venv is missing, create it by calling scripts/create_venv.ps1.
+    [switch]$CreateIfMissing,
+
+    # Relative path (from project root) to the create script.
+    [string]$CreateScript = "scripts/create_venv.ps1"
+)
+
 $ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Resolve-ProjectRoot {
+    param([string]$StartDir)
+
+    # Walk up looking for common repo/project markers.
+    $markers = @(".git", "pyproject.toml", "requirements.txt")
+
+    $dir = (Resolve-Path $StartDir).Path
+    while ($true) {
+        foreach ($m in $markers) {
+            if (Test-Path -LiteralPath (Join-Path $dir $m)) {
+                return (Resolve-Path $dir)
+            }
+        }
+
+        $parent = Split-Path $dir -Parent
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $dir) { break }
+        $dir = $parent
+    }
+
+    # Fallback: parent of the directory containing this script (works for /scripts layout).
+    return (Resolve-Path (Join-Path $StartDir ".."))
+}
 
 # ------------------------------------------------------------
 # Enforce dot-sourcing
@@ -12,27 +57,75 @@ $ErrorActionPreference = "Stop"
 if ($MyInvocation.InvocationName -ne '.') {
     Write-Host "ERROR: This script must be dot-sourced to activate the virtual environment." -ForegroundColor Red
     Write-Host "Run it like this:" -ForegroundColor Yellow
-    Write-Host "  . .\scripts\activate_venv.ps1" -ForegroundColor Cyan
+
+    if ($PSCommandPath) {
+        Write-Host ("  . `"{0}`"" -f $PSCommandPath) -ForegroundColor Cyan
+    } else {
+        Write-Host "  . .\scripts\activate_venv.ps1" -ForegroundColor Cyan
+    }
     return
 }
 
 # ------------------------------------------------------------
-# Resolve project root (parent of /scripts)
+# Resolve project root + venv paths
 # ------------------------------------------------------------
-$ProjectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-$VenvPath    = Join-Path $ProjectRoot ".venv"
-$Activate    = Join-Path $VenvPath "Scripts\Activate.ps1"
+$RootPath = if ($ProjectRoot) {
+    (Resolve-Path $ProjectRoot).Path
+} else {
+    (Resolve-ProjectRoot -StartDir $PSScriptRoot).Path
+}
+
+$VenvPath   = Join-Path $RootPath $VenvDir
+$ActivatePs = Join-Path $VenvPath "Scripts\Activate.ps1"
+
+Write-Host ("Project root: {0}" -f $RootPath) -ForegroundColor DarkGray
+Write-Host ("Venv path:     {0}" -f $VenvPath) -ForegroundColor DarkGray
 
 # ------------------------------------------------------------
-# Guard: venv exists
+# Guard / optional creation
 # ------------------------------------------------------------
-if (-not (Test-Path $Activate)) {
-    Write-Host "Virtual environment not found at $VenvPath" -ForegroundColor Red
-    Write-Host "Run scripts/create_venv.ps1 first." -ForegroundColor Yellow
-    return
+if (-not (Test-Path -LiteralPath $ActivatePs)) {
+    if (-not $CreateIfMissing) {
+        Write-Host ("Virtual environment not found (expected: {0})" -f $VenvPath) -ForegroundColor Red
+        Write-Host "Create it first:" -ForegroundColor Yellow
+        Write-Host "  .\scripts\create_venv.ps1" -ForegroundColor Cyan
+        Write-Host "Or auto-create then activate:" -ForegroundColor Yellow
+        Write-Host "  . .\scripts\activate_venv.ps1 -CreateIfMissing" -ForegroundColor Cyan
+        return
+    }
+
+    $CreateScriptPath = Join-Path $RootPath $CreateScript
+    if (-not (Test-Path -LiteralPath $CreateScriptPath)) {
+        throw "Create script not found at: $CreateScriptPath"
+    }
+
+    Write-Host "Venv missing; creating it now..." -ForegroundColor Yellow
+
+    # Call without parameters so it works with the simplest create_venv.ps1 implementation.
+    & $CreateScriptPath
+
+    # Re-check expected activation script.
+    if (-not (Test-Path -LiteralPath $ActivatePs)) {
+        # Common case: create_venv.ps1 always creates '.venv', but caller set -VenvDir to something else.
+        $DefaultActivate = Join-Path (Join-Path $RootPath ".venv") "Scripts\Activate.ps1"
+        if ($VenvDir -ne ".venv" -and (Test-Path -LiteralPath $DefaultActivate)) {
+            throw "Venv was created at '.venv' but you requested '$VenvDir'. Re-run with -VenvDir .venv or update $CreateScript to support custom venv paths."
+        }
+
+        throw "Venv creation did not produce expected activation script: $ActivatePs"
+    }
 }
 
 # ------------------------------------------------------------
-# Activate
+# Activate (dot-source into current session)
 # ------------------------------------------------------------
-& $Activate
+. $ActivatePs
+
+# Optional: show interpreter for quick sanity check
+try {
+    $py = Get-Command python -ErrorAction Stop
+    $pyVer = & python -c "import sys; print('%d.%d.%d' % sys.version_info[:3])"
+    Write-Host ("Activated: python {0} ({1})" -f $pyVer.Trim(), $py.Source) -ForegroundColor Green
+} catch {
+    Write-Host "Activated venv. (python not resolved on PATH in this session.)" -ForegroundColor Green
+}

--- a/scripts/check_python.ps1
+++ b/scripts/check_python.ps1
@@ -1,10 +1,103 @@
-$python = Get-Command python -ErrorAction SilentlyContinue
+# ------------------------------------------------------------
+# Check Python availability + minimum version
+#
+# Exit codes:
+#   0 = OK
+#   1 = Python missing / too old / not runnable
+#
+# Usage examples:
+#   .\scripts\check_python.ps1
+#   .\scripts\check_python.ps1 -MinPythonVersion 3.11
+# ------------------------------------------------------------
 
-if (-not $python) {
-    Write-Host "Python is not installed."
-    Write-Host "Please install Python 3.10+ from https://www.python.org/downloads/"
-    exit 1
+[CmdletBinding()]
+param(
+    [version]$MinPythonVersion = '3.10',
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Get-PythonRunner {
+    param([version]$MinV)
+
+    $maj = $MinV.Major
+    $min = $MinV.Minor
+
+    # Prefer Windows Python Launcher if available.
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        # Try to target the requested minor version first (e.g., py -3.10)
+        $candidates = @(
+            @{ Cmd = 'py'; Args = @("-$maj.$min") },
+            @{ Cmd = 'py'; Args = @('-3') }
+        )
+
+        foreach ($cand in $candidates) {
+            try {
+                $null = & $cand.Cmd @($cand.Args) -c "import sys" 2>$null
+                if ($LASTEXITCODE -eq 0) { return $cand }
+            } catch { }
+        }
+    }
+
+    # Fallback to python on PATH.
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        return @{ Cmd = 'python'; Args = @() }
+    }
+
+    return $null
 }
 
-$version = python --version
-Write-Host "Found $version"
+function Get-PythonVersion {
+    param($Runner)
+
+    $code = 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")'
+    $out = & $Runner.Cmd @($Runner.Args) -c $code 2>$null
+
+    if ($LASTEXITCODE -ne 0 -or -not $out) {
+        throw 'Python was found but could not be executed.'
+    }
+
+    return [version]$out.Trim()
+}
+
+try {
+    $runner = Get-PythonRunner -MinV $MinPythonVersion
+    if (-not $runner) {
+        if (-not $Quiet) {
+            Write-Host "Python not found." -ForegroundColor Red
+            Write-Host "Install Python $MinPythonVersion+ and ensure either 'py' or 'python' is available." -ForegroundColor Yellow
+            Write-Host "Windows installer: https://www.python.org/downloads/" -ForegroundColor DarkGray
+        }
+        exit 1
+    }
+
+    $pyVer = Get-PythonVersion -Runner $runner
+
+    if ($pyVer -lt $MinPythonVersion) {
+        if (-not $Quiet) {
+            Write-Host "Python version too old: $pyVer" -ForegroundColor Red
+            Write-Host "Required: $MinPythonVersion or newer" -ForegroundColor Yellow
+        }
+        exit 1
+    }
+
+    if (-not $Quiet) {
+        $cmdPath = (Get-Command $runner.Cmd -ErrorAction SilentlyContinue).Source
+        $args = ($runner.Args -join ' ')
+        if ([string]::IsNullOrWhiteSpace($args)) { $args = '(none)' }
+
+        Write-Host "Found Python $pyVer" -ForegroundColor Green
+        Write-Host "Command: $($runner.Cmd)  Args: $args" -ForegroundColor DarkGray
+        if ($cmdPath) { Write-Host "Resolved: $cmdPath" -ForegroundColor DarkGray }
+    }
+
+    exit 0
+}
+catch {
+    if (-not $Quiet) {
+        Write-Host "Python check failed: $($_.Exception.Message)" -ForegroundColor Red
+    }
+    exit 1
+}

--- a/scripts/create_venv.ps1
+++ b/scripts/create_venv.ps1
@@ -1,50 +1,116 @@
 # ------------------------------------------------------------
 # Create virtual environment (one-time setup)
-# Always creates .venv at project root
+# Always creates .venv at project root by default
 # DOES NOT activate the environment
 # ------------------------------------------------------------
 
+[CmdletBinding()]
+param(
+    [string]$VenvDir = ".venv",
+    [string]$Requirements = "requirements.txt",
+    [switch]$Force,
+    [version]$MinPythonVersion = "3.9"
+)
+
 $ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Resolve-ProjectRoot {
+    param([string]$StartDir)
+
+    # Default behavior: parent of /scripts (your current logic)
+    $candidate = Resolve-Path (Join-Path $StartDir "..")
+
+    # Optional robustness: walk upwards for a marker
+    $markers = @(".git", "pyproject.toml", "requirements.txt")
+    $dir = $candidate.Path
+    while ($true) {
+        foreach ($m in $markers) {
+            if (Test-Path (Join-Path $dir $m)) { return (Resolve-Path $dir) }
+        }
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir -or [string]::IsNullOrWhiteSpace($parent)) { break }
+        $dir = $parent
+    }
+
+    return $candidate
+}
+
+function Get-PythonCommand {
+    # Prefer Python Launcher if present (common on Windows)
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        return @{ Cmd = "py"; Args = @("-3") }
+    }
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        return @{ Cmd = "python"; Args = @() }
+    }
+    throw "Python not found. Install Python $MinPythonVersion+ and ensure 'py' or 'python' is available."
+}
+
+function Get-PythonVersion {
+    param($py)
+
+    $code = 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")'
+    $v = & $py.Cmd @($py.Args) -c $code
+    return [version]$v.Trim()
+}
 
 # ------------------------------------------------------------
-# Resolve project root (parent of /scripts)
+# Resolve paths
 # ------------------------------------------------------------
-$ProjectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-$VenvPath    = Join-Path $ProjectRoot ".venv"
-$ReqFile     = Join-Path $ProjectRoot "requirements.txt"
+$ProjectRoot = Resolve-ProjectRoot -StartDir $PSScriptRoot
+$VenvPath    = Join-Path $ProjectRoot $VenvDir
+$ReqFile     = Join-Path $ProjectRoot $Requirements
+
+Write-Host "Project root: $ProjectRoot" -ForegroundColor DarkGray
 
 # ------------------------------------------------------------
-# Guard: already exists
+# Guard: already exists (unless -Force)
 # ------------------------------------------------------------
 if (Test-Path $VenvPath) {
-    Write-Host "Virtual environment already exists at $VenvPath" -ForegroundColor Yellow
-    return
+    if (-not $Force) {
+        Write-Host "Virtual environment already exists at $VenvPath" -ForegroundColor Yellow
+        return
+    }
+    Write-Host "Removing existing venv at $VenvPath (Force)..." -ForegroundColor Yellow
+    Remove-Item -LiteralPath $VenvPath -Recurse -Force
 }
 
 # ------------------------------------------------------------
-# Guard: Python availability
+# Python availability + version check
 # ------------------------------------------------------------
-try {
-    python --version | Out-Null
-} catch {
-    Write-Host "ERROR: Python not found. Install Python 3.9+ and add it to PATH." -ForegroundColor Red
-    exit 1
+$py = Get-PythonCommand
+$pyVer = Get-PythonVersion -py $py
+
+if ($pyVer -lt $MinPythonVersion) {
+    throw "Python $MinPythonVersion+ is required. Found: $pyVer"
 }
+
+Write-Host "Using Python $pyVer ($($py.Cmd) $($py.Args -join ' '))" -ForegroundColor DarkGray
 
 # ------------------------------------------------------------
 # Create venv
 # ------------------------------------------------------------
 Write-Host "Creating virtual environment at $VenvPath" -ForegroundColor Cyan
-python -m venv $VenvPath
+& $py.Cmd @($py.Args) -m venv $VenvPath
+
+$VenvPython = Join-Path $VenvPath "Scripts\python.exe"
+if (-not (Test-Path $VenvPython)) {
+    throw "Venv python not found at expected path: $VenvPython"
+}
 
 # ------------------------------------------------------------
-# Install dependencies (without activating)
+# Upgrade packaging tooling + install deps
 # ------------------------------------------------------------
+Write-Host "Upgrading pip/setuptools/wheel..." -ForegroundColor Yellow
+& $VenvPython -m pip install --upgrade pip setuptools wheel
+
 if (Test-Path $ReqFile) {
-    Write-Host "Installing dependencies from requirements.txt..." -ForegroundColor Yellow
-    & (Join-Path $VenvPath "Scripts\python.exe") -m pip install -r $ReqFile
+    Write-Host "Installing dependencies from $Requirements..." -ForegroundColor Yellow
+    & $VenvPython -m pip install -r $ReqFile
 } else {
-    Write-Host "requirements.txt not found. Skipping dependency install." -ForegroundColor Yellow
+    Write-Host "$Requirements not found. Skipping dependency install." -ForegroundColor Yellow
 }
 
 Write-Host "Virtual environment created successfully." -ForegroundColor Green
+Write-Host "To activate: `"$VenvPath\Scripts\Activate.ps1`"" -ForegroundColor DarkGray

--- a/scripts/sync_venv.ps1
+++ b/scripts/sync_venv.ps1
@@ -1,49 +1,239 @@
-$VenvPath = ".venv"
-$RequirementsFile = "requirements.txt"
-$HashFile = "$VenvPath\.requirements.hash"
+# ------------------------------------------------------------
+# Sync (create/update) a project virtual environment
+#
+# Behavior:
+#   - Resolves project root (walks upward for .git / pyproject.toml / requirements.txt)
+#   - Creates the venv if missing (or recreates with -Force)
+#   - Installs dependencies only when inputs change (requirements/constraints content hash + python version)
+#   - Uses the venv's python directly (no activation required)
+#
+# Exit codes:
+#   0 = OK
+#   1 = failure (missing python, venv create failed, pip install failed)
+#
+# Usage examples:
+#   .\scripts\sync_venv.ps1
+#   .\scripts\sync_venv.ps1 -Force
+#   .\scripts\sync_venv.ps1 -Requirements requirements-dev.txt
+#   .\scripts\sync_venv.ps1 -Constraints constraints.txt
+#   .\scripts\sync_venv.ps1 -Quiet
+# ------------------------------------------------------------
 
-# Create venv if missing
-if (-not (Test-Path $VenvPath)) {
-    Write-Host ".venv not found. Creating virtual environment..."
-    python -m venv $VenvPath
-}
+[CmdletBinding()]
+param(
+    [string]$VenvDir = ".venv",
+    [string]$Requirements = "requirements.txt",
+    [string]$Constraints = "",
+    [switch]$Force,
+    [switch]$NoUpgradePip,
+    [switch]$Quiet,
+    [version]$MinPythonVersion = "3.10",
+    [string]$ProjectRoot
+)
 
-# Activate venv
-& "$VenvPath\Scripts\Activate.ps1"
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
 
-# No requirements file → nothing to sync
-if (-not (Test-Path $RequirementsFile)) {
-    Write-Host "requirements.txt not found. Skipping dependency sync."
-    return
-}
+function Resolve-ProjectRoot {
+    param([string]$StartDir)
 
-# Compute current requirements hash
-$CurrentHash = (Get-FileHash $RequirementsFile -Algorithm SHA256).Hash
+    $markers = @(".git", "pyproject.toml", "requirements.txt")
+    $dir = (Resolve-Path $StartDir).Path
 
-# Load previous hash if it exists
-$PreviousHash = if (Test-Path $HashFile) {
-    Get-Content $HashFile
-} else {
-    ""
-}
+    while ($true) {
+        foreach ($m in $markers) {
+            if (Test-Path -LiteralPath (Join-Path $dir $m)) {
+                return (Resolve-Path $dir).Path
+            }
+        }
 
-# Sync only if requirements changed
-if ($CurrentHash -ne $PreviousHash) {
-    Write-Host "requirements.txt changed. Updating virtual environment..."
-
-    python -m pip install --upgrade pip --quiet
-    python -m pip install -r $RequirementsFile
-    $InstallExitCode = $LASTEXITCODE
-
-    if ($InstallExitCode -eq 0) {
-        $CurrentHash | Out-File $HashFile -Encoding ascii
-        Write-Host "Virtual environment updated."
+        $parent = Split-Path $dir -Parent
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $dir) { break }
+        $dir = $parent
     }
-    else {
-        Write-Error "Dependency installation failed. Hash not updated."
-        exit $InstallExitCode
+
+    # Fallback: parent of the script directory (matches /scripts layout)
+    return (Resolve-Path (Join-Path $StartDir "..")).Path
+}
+
+function Get-PythonRunner {
+    param([version]$MinV)
+
+    $maj = $MinV.Major
+    $min = $MinV.Minor
+
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        # Try exact minor first (e.g. py -3.10), then generic py -3
+        $candidates = @(
+            @{ Cmd = "py"; Args = @("-$maj.$min") },
+            @{ Cmd = "py"; Args = @("-3") }
+        )
+
+        foreach ($cand in $candidates) {
+            try {
+                $null = & $cand.Cmd @($cand.Args) -c "import sys" 2>$null
+                if ($LASTEXITCODE -eq 0) { return $cand }
+            } catch { }
+        }
+    }
+
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        return @{ Cmd = "python"; Args = @() }
+    }
+
+    return $null
+}
+
+function Get-PythonVersion {
+    param($Runner)
+    $code = 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")'
+    $out = & $Runner.Cmd @($Runner.Args) -c $code 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $out) {
+        throw "Python was found but could not be executed."
+    }
+    return [version]$out.Trim()
+}
+
+function Read-Stamp {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    try {
+        $raw = Get-Content -LiteralPath $Path -Raw
+        if ([string]::IsNullOrWhiteSpace($raw)) { return $null }
+        return ($raw | ConvertFrom-Json)
+    } catch {
+        return $null
     }
 }
-else {
-    Write-Host "Virtual environment already up to date."
+
+function Write-Stamp {
+    param(
+        [string]$Path,
+        [string]$ReqHash,
+        [string]$ConHash,
+        [string]$PyVer
+    )
+    $obj = [ordered]@{
+        requirements_sha256 = $ReqHash
+        constraints_sha256  = $ConHash
+        python_version      = $PyVer
+        stamped_utc         = (Get-Date).ToUniversalTime().ToString("o")
+    }
+    ($obj | ConvertTo-Json -Depth 3) | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Hash-FileOrEmpty {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return "" }
+    if (-not (Test-Path -LiteralPath $Path)) { return "" }
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+}
+
+try {
+    $RootPath = if ($ProjectRoot) { (Resolve-Path $ProjectRoot).Path } else { Resolve-ProjectRoot -StartDir $PSScriptRoot }
+    $VenvPath = Join-Path $RootPath $VenvDir
+
+    $ReqFile = Join-Path $RootPath $Requirements
+    $ConFile = if ([string]::IsNullOrWhiteSpace($Constraints)) { "" } else { (Join-Path $RootPath $Constraints) }
+
+    $VenvPython = Join-Path $VenvPath "Scripts\python.exe"
+    $StampFile  = Join-Path $VenvPath ".requirements.stamp.json"
+
+    if (-not $Quiet) {
+        Write-Host ("Project root: {0}" -f $RootPath) -ForegroundColor DarkGray
+        Write-Host ("Venv path:     {0}" -f $VenvPath) -ForegroundColor DarkGray
+        Write-Host ("Requirements:  {0}" -f $ReqFile) -ForegroundColor DarkGray
+        if ($ConFile) { Write-Host ("Constraints:   {0}" -f $ConFile) -ForegroundColor DarkGray }
+    }
+
+    # Locate runnable python for venv creation/version check
+    $runner = Get-PythonRunner -MinV $MinPythonVersion
+    if (-not $runner) {
+        if (-not $Quiet) {
+            Write-Host "Python not found." -ForegroundColor Red
+            Write-Host ("Install Python {0}+ and ensure 'py' or 'python' is available." -f $MinPythonVersion) -ForegroundColor Yellow
+        }
+        exit 1
+    }
+
+    $sysPyVer = Get-PythonVersion -Runner $runner
+    if ($sysPyVer -lt $MinPythonVersion) {
+        if (-not $Quiet) {
+            Write-Host ("Python version too old: {0}" -f $sysPyVer) -ForegroundColor Red
+            Write-Host ("Required: {0} or newer" -f $MinPythonVersion) -ForegroundColor Yellow
+        }
+        exit 1
+    }
+
+    # (Re)create venv if needed
+    if ($Force -and (Test-Path -LiteralPath $VenvPath)) {
+        if (-not $Quiet) { Write-Host "Removing existing venv (Force)..." -ForegroundColor Yellow }
+        Remove-Item -LiteralPath $VenvPath -Recurse -Force
+    }
+
+    if (-not (Test-Path -LiteralPath $VenvPython)) {
+        if (-not $Quiet) { Write-Host "Creating virtual environment..." -ForegroundColor Cyan }
+        & $runner.Cmd @($runner.Args) -m venv $VenvPath
+        if ($LASTEXITCODE -ne 0) { throw "Failed to create venv at: $VenvPath" }
+        if (-not (Test-Path -LiteralPath $VenvPython)) { throw "Venv python not found at: $VenvPython" }
+    }
+
+    # No requirements => nothing to sync (but venv ensured)
+    if (-not (Test-Path -LiteralPath $ReqFile)) {
+        if (-not $Quiet) { Write-Host "Requirements file not found; skipping dependency sync." -ForegroundColor Yellow }
+        exit 0
+    }
+
+    if ($ConFile -and (-not (Test-Path -LiteralPath $ConFile))) {
+        throw "Constraints file not found: $ConFile"
+    }
+
+    # Decide whether sync needed
+    $reqHash = Hash-FileOrEmpty -Path $ReqFile
+    $conHash = Hash-FileOrEmpty -Path $ConFile
+    $venvPyVer = (& $VenvPython -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")' 2>$null).Trim()
+
+    $stamp = Read-Stamp -Path $StampFile
+    $needsSync =
+        (-not $stamp) -or
+        ($stamp.requirements_sha256 -ne $reqHash) -or
+        ($stamp.constraints_sha256  -ne $conHash) -or
+        ($stamp.python_version      -ne $venvPyVer)
+
+    if (-not $needsSync) {
+        if (-not $Quiet) { Write-Host "Virtual environment already up to date." -ForegroundColor Green }
+        exit 0
+    }
+
+    if (-not $Quiet) { Write-Host "Updating virtual environment..." -ForegroundColor Yellow }
+
+    # Upgrade packaging tooling unless explicitly disabled
+    if (-not $NoUpgradePip) {
+        $pipArgs = @("-m","pip","install","--upgrade","pip","setuptools","wheel","--disable-pip-version-check")
+        if ($Quiet) { $pipArgs += "--quiet" }
+        & $VenvPython @pipArgs
+        if ($LASTEXITCODE -ne 0) { throw "Failed to upgrade pip tooling." }
+    }
+
+    # Install requirements
+    $installArgs = @("-m","pip","install","-r",$ReqFile,"--disable-pip-version-check")
+    if ($ConFile) { $installArgs += @("-c",$ConFile) }
+    if ($Quiet) { $installArgs += "--quiet" }
+
+    & $VenvPython @installArgs
+    $code = $LASTEXITCODE
+    if ($code -ne 0) {
+        if (-not $Quiet) { Write-Host "Dependency installation failed; stamp not updated." -ForegroundColor Red }
+        exit $code
+    }
+
+    Write-Stamp -Path $StampFile -ReqHash $reqHash -ConHash $conHash -PyVer $venvPyVer
+    if (-not $Quiet) { Write-Host "Virtual environment updated." -ForegroundColor Green }
+    exit 0
+}
+catch {
+    if (-not $Quiet) {
+        Write-Host ("sync_venv failed: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    }
+    exit 1
 }


### PR DESCRIPTION
Add robust project-root detection + path resolution

Prefer py launcher fallback; enforce minimum Python version checks

- Use venv python.exe directly (no reliance on activation side-effects)
- Add safe flags/params (Force, Quiet, optional create-if-missing)
- Improve error handling + exit codes for CI reliability

Closes #31