### PR TITLE
Enforce date32 for dimension Parquet + stabilize dimension generation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ sales:
   parquet_folder: "./data/parquet_dims"
   out_folder: "./data/fact_out"
 
-  total_rows: 2002300
+  total_rows: 200230
   chunk_size: 1000000
 
   file_format: "csv"          # csv | parquet | deltaparquet

--- a/src/dimensions/currency.py
+++ b/src/dimensions/currency.py
@@ -1,12 +1,21 @@
 # ---------------------------------------------------------
-#  CURRENCY DIMENSION (FIXED VERSIONING + DATE-AWARE)
+#  CURRENCY DIMENSION (PIPELINE READY – OPTIMIZED)
+#  - Minimal versioning deps
+#  - Validated + deterministic keys
+#  - Uses shared parquet writer utility (safe even with no date cols)
 # ---------------------------------------------------------
 
-import pandas as pd
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
 
 from src.utils.logging_utils import info, skip, stage
+from src.utils.output_utils import write_parquet_with_date32
 from src.versioning.version_store import should_regenerate, save_version
+
 
 CURRENCY_NAME_MAP = {
     "USD": "US Dollar",
@@ -28,62 +37,127 @@ CURRENCY_NAME_MAP = {
 }
 
 
-def generate_currency_dimension(currencies):
-    df = pd.DataFrame({
-        "CurrencyKey": range(1, len(currencies) + 1),
-        "ToCurrency": currencies,
-        "CurrencyName": [CURRENCY_NAME_MAP.get(c, c) for c in currencies],
-    })
+# ---------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------
+
+def _require_section(cfg: Dict, name: str) -> Dict:
+    if not isinstance(cfg, dict):
+        raise TypeError("cfg must be a dict")
+    if name not in cfg or not isinstance(cfg[name], dict):
+        raise KeyError(f"Missing required config section: '{name}'")
+    return cfg[name]
+
+
+def _get_effective_dates(cfg: Dict, ex_cfg: Dict) -> Dict:
+    """
+    Currency dimension itself doesn't *need* dates, but you intentionally
+    tie versioning to the effective FX window, so we preserve that behavior.
+    """
+    use_global = bool(ex_cfg.get("use_global_dates", True))
+
+    if use_global:
+        defaults_dates = (
+            (cfg.get("defaults", {}) or {}).get("dates")
+            or (cfg.get("_defaults", {}) or {}).get("dates")
+            or {}
+        )
+        return defaults_dates if isinstance(defaults_dates, dict) else {}
+    else:
+        override_dates = ((ex_cfg.get("override", {}) or {}).get("dates")) or {}
+        return override_dates if isinstance(override_dates, dict) else {}
+
+
+def _normalize_currency_list(currencies: List[str]) -> List[str]:
+    if not isinstance(currencies, list) or not currencies:
+        raise ValueError("exchange_rates.currencies must be a non-empty list")
+
+    normalized: List[str] = []
+    seen = set()
+
+    for c in currencies:
+        if not isinstance(c, str) or not c.strip():
+            raise ValueError(f"Invalid currency code in exchange_rates.currencies: {c!r}")
+
+        code = c.strip().upper()
+
+        # Light validation (ISO-4217 is 3 letters; keep it strict to avoid junk)
+        if len(code) != 3 or not code.isalpha():
+            raise ValueError(f"Currency code must be 3 letters (e.g. USD). Got: {c!r}")
+
+        if code in seen:
+            raise ValueError(f"Duplicate currency code in exchange_rates.currencies: {code}")
+
+        seen.add(code)
+        normalized.append(code)
+
+    return normalized
+
+
+def build_dim_currency(currencies: List[str]) -> pd.DataFrame:
+    currencies = _normalize_currency_list(currencies)
+
+    df = pd.DataFrame(
+        {
+            "CurrencyKey": pd.RangeIndex(start=1, stop=len(currencies) + 1, step=1, name=None).astype("int64"),
+            "ToCurrency": currencies,
+            "CurrencyName": [CURRENCY_NAME_MAP.get(c, c) for c in currencies],
+        }
+    )
     return df
 
 
-def run_currency(cfg, parquet_folder: Path):
+# ---------------------------------------------------------
+# Pipeline wrapper
+# ---------------------------------------------------------
+
+def run_currency(cfg: Dict, parquet_folder: Path) -> None:
     """
-    Currency dimension should depend ONLY on:
-      - exchange_rates section
-      - defaults.dates (ONLY if use_global_dates = true)
+    Versioning dependencies (minimal, intentional):
+      - exchange_rates.currencies (+ base_currency/use_global_dates)
+      - effective FX date window (global dates if use_global_dates=true, else override.dates)
     """
+    ex_cfg = _require_section(cfg, "exchange_rates")
+    cur_cfg = _require_section(cfg, "currency")
 
-    out_path = parquet_folder / "currency.parquet"
+    out_path = Path(parquet_folder) / "currency.parquet"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    ex_cfg = cfg["exchange_rates"]
-    cur_cfg = cfg["currency"]
+    force = bool(cur_cfg.get("_force_regenerate", False))
 
-    force = cur_cfg.get("_force_regenerate", False)
+    currencies = _normalize_currency_list(ex_cfg.get("currencies"))
+    effective_dates = _get_effective_dates(cfg, ex_cfg)
 
-    # --------------------------
-    # Determine which date window we depend on
-    # --------------------------
-    if ex_cfg.get("use_global_dates", True):
-        defaults_dates = (
-            cfg.get("defaults", {}).get("dates")
-            or cfg.get("_defaults", {}).get("dates")
-        )
-        date_dependency = defaults_dates
-    else:
-        date_dependency = ex_cfg.get("override", {}).get("dates", {})
-
-    # --------------------------
-    # Versioning: 
-    # Use only exchange_rates section + date dependency
-    # --------------------------
+    # Minimal version_cfg: avoids regen churn when unrelated exchange_rates keys change
     version_cfg = {
-        **ex_cfg,
-        "effective_dates": date_dependency
+        "currencies": currencies,
+        "base_currency": (ex_cfg.get("base_currency") or "").upper(),
+        "use_global_dates": bool(ex_cfg.get("use_global_dates", True)),
+        "effective_dates": effective_dates,
     }
 
     if not force and not should_regenerate("currency", version_cfg, out_path):
         skip("Currency up-to-date; skipping.")
         return
 
-    # --------------------------
-    # Build dimension
-    # --------------------------
-    currencies = ex_cfg["currencies"]
+    # Optional parquet knobs (consistent with other dims)
+    compression = cur_cfg.get("parquet_compression", "snappy")
+    compression_level = cur_cfg.get("parquet_compression_level", None)
+    force_date32 = bool(cur_cfg.get("force_date32", True))
 
     with stage("Generating Currency"):
-        df = generate_currency_dimension(currencies)
-        df.to_parquet(out_path, index=False)
+        df = build_dim_currency(currencies)
+
+        # Currency has no datetime cols; this will just write parquet normally,
+        # but keeps a consistent write path across dims.
+        write_parquet_with_date32(
+            df,
+            out_path,
+            cast_all_datetime=False,
+            compression=str(compression),
+            compression_level=(int(compression_level) if compression_level is not None else None),
+            force_date32=force_date32,
+        )
 
     save_version("currency", version_cfg, out_path)
     info(f"Currency dimension written: {out_path}")

--- a/src/dimensions/dates.py
+++ b/src/dimensions/dates.py
@@ -1,11 +1,19 @@
 # ---------------------------------------------------------
 #  DATES DIMENSION (PIPELINE READY)
+#  - Keeps date columns as datetime64[ns] for fast generation
+#  - Writes Parquet date columns as Arrow date32 (when pyarrow is available)
+#    so Power Query imports them as Date (not DateTime) without transforms.
 # ---------------------------------------------------------
 
-import pandas as pd
-import numpy as np
-import re
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from src.utils.output_utils import write_parquet_with_date32
+
+import numpy as np
+import pandas as pd
 
 from src.utils import info, skip, stage
 from src.versioning import should_regenerate, save_version
@@ -15,22 +23,24 @@ from src.versioning import should_regenerate, save_version
 # DATE COLUMN GROUPS
 # ---------------------------------------------------------
 
+BASE_COLUMNS = ["Date", "DateKey"]
+
 CALENDAR_COLUMNS = [
-    "Date","DateKey",
-    "Year","IsYearStart","IsYearEnd",
-    "Quarter","QuarterStartDate","QuarterEndDate",
-    "IsQuarterStart","IsQuarterEnd",
+    "Date", "DateKey",
+    "Year", "IsYearStart", "IsYearEnd",
+    "Quarter", "QuarterStartDate", "QuarterEndDate",
+    "IsQuarterStart", "IsQuarterEnd",
     "QuarterYear",
-    "Month","MonthName","MonthShort",
-    "MonthStartDate","MonthEndDate",
-    "MonthYear","MonthYearNumber","CalendarMonthIndex","CalendarQuarterIndex",
-    "IsMonthStart","IsMonthEnd",
+    "Month", "MonthName", "MonthShort",
+    "MonthStartDate", "MonthEndDate",
+    "MonthYear", "MonthYearNumber", "CalendarMonthIndex", "CalendarQuarterIndex",
+    "IsMonthStart", "IsMonthEnd",
     "WeekOfMonth",
-    "Day","DayName","DayShort","DayOfYear","DayOfWeek",
-    "IsWeekend","IsBusinessDay",
-    "NextBusinessDay","PreviousBusinessDay",
-    "IsToday","IsCurrentYear","IsCurrentMonth",
-    "IsCurrentQuarter","CurrentDayOffset"
+    "Day", "DayName", "DayShort", "DayOfYear", "DayOfWeek",
+    "IsWeekend", "IsBusinessDay",
+    "NextBusinessDay", "PreviousBusinessDay",
+    "IsToday", "IsCurrentYear", "IsCurrentMonth",
+    "IsCurrentQuarter", "CurrentDayOffset",
 ]
 
 ISO_COLUMNS = [
@@ -41,22 +51,42 @@ ISO_COLUMNS = [
 ]
 
 FISCAL_COLUMNS = [
-    "FiscalYearStartYear","FiscalMonthNumber","FiscalQuarterNumber",
-    "FiscalMonthIndex","FiscalQuarterIndex",
-    "FiscalQuarterName","FiscalYearBin",
-    "FiscalYearMonthNumber","FiscalYearQuarterNumber",
-    "FiscalYearStartDate","FiscalYearEndDate",
-    "FiscalQuarterStartDate","FiscalQuarterEndDate",
-    "IsFiscalYearStart","IsFiscalYearEnd",
-    "IsFiscalQuarterStart","IsFiscalQuarterEnd",
-    "FiscalYear","FiscalYearLabel",
+    "FiscalYearStartYear", "FiscalMonthNumber", "FiscalQuarterNumber",
+    "FiscalMonthIndex", "FiscalQuarterIndex",
+    "FiscalQuarterName", "FiscalYearBin",
+    "FiscalYearMonthNumber", "FiscalYearQuarterNumber",
+    "FiscalYearStartDate", "FiscalYearEndDate",
+    "FiscalQuarterStartDate", "FiscalQuarterEndDate",
+    "IsFiscalYearStart", "IsFiscalYearEnd",
+    "IsFiscalQuarterStart", "IsFiscalQuarterEnd",
+    "FiscalYear", "FiscalYearLabel",
 ]
 
 
-def resolve_date_columns(dates_cfg):
-    include_cfg = dates_cfg.get("include", {})
+def _dedupe_preserve_order(items: Sequence[str]) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for x in items:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
 
-    cols = []
+
+def resolve_date_columns(dates_cfg: Dict) -> List[str]:
+    """
+    Resolve output columns based on dates.include, but ALWAYS keep Date + DateKey.
+
+    dates.include:
+      calendar: true/false
+      iso: true/false
+      fiscal: true/false
+    """
+    include_cfg = (dates_cfg or {}).get("include", {}) or {}
+
+    cols: List[str] = []
+    cols.extend(BASE_COLUMNS)  # always present
+
     if include_cfg.get("calendar", True):
         cols.extend(CALENDAR_COLUMNS)
     if include_cfg.get("iso", False):
@@ -64,59 +94,74 @@ def resolve_date_columns(dates_cfg):
     if include_cfg.get("fiscal", False):
         cols.extend(FISCAL_COLUMNS)
 
-    return cols
+    return _dedupe_preserve_order(cols)
 
 
 # ---------------------------------------------------------
-# DATE GENERATOR (LOGIC UNCHANGED)
+# DATE GENERATOR
 # ---------------------------------------------------------
 
-def generate_date_table(start_date, end_date, first_fy_month):
+def generate_date_table(
+    start_date: pd.Timestamp,
+    end_date: pd.Timestamp,
+    fiscal_start_month: int,
+    *,
+    as_of_date: Optional[pd.Timestamp] = None,
+) -> pd.DataFrame:
+    """
+    Build a date dimension between start_date and end_date inclusive.
 
-    start_date = start_date or "2020-01-01"
-    end_date = end_date or "2026-12-31"
-    fy_start_month = first_fy_month or 5
+    - Uses datetime64[ns] internally (fast)
+    - 'as_of_date' controls IsToday/IsCurrent* and CurrentDayOffset deterministically.
+      If None, defaults to end_date (stable for synthetic datasets).
+    """
+    if fiscal_start_month < 1 or fiscal_start_month > 12:
+        raise ValueError(f"fiscal_start_month must be 1..12, got {fiscal_start_month}")
+
+    start_date = pd.to_datetime(start_date).normalize()
+    end_date = pd.to_datetime(end_date).normalize()
+
+    if as_of_date is None:
+        as_of_date = end_date
+    else:
+        as_of_date = pd.to_datetime(as_of_date).normalize()
 
     df = pd.DataFrame({"Date": pd.date_range(start_date, end_date, freq="D")})
+    df["DateKey"] = df["Date"].dt.strftime("%Y%m%d").astype(np.int64)
 
-    df["DateKey"] = df["Date"].dt.strftime("%Y%m%d").astype(int)
-
-    df["Year"] = df["Date"].dt.year
-    df["Month"] = df["Date"].dt.month
-    df["Day"] = df["Date"].dt.day
-    df["Quarter"] = df["Date"].dt.quarter
+    # Basic parts
+    df["Year"] = df["Date"].dt.year.astype(int)
+    df["Month"] = df["Date"].dt.month.astype(int)
+    df["Day"] = df["Date"].dt.day.astype(int)
+    df["Quarter"] = df["Date"].dt.quarter.astype(int)
 
     df["MonthName"] = df["Date"].dt.strftime("%B")
     df["MonthShort"] = df["Date"].dt.strftime("%b")
-
-    df["MonthStartDate"] = df["Date"].values.astype("datetime64[M]")
-    df["MonthEndDate"] = df["MonthStartDate"] + pd.offsets.MonthEnd(1)
-
     df["DayName"] = df["Date"].dt.strftime("%A")
     df["DayShort"] = df["Date"].dt.strftime("%a")
-    df["DayOfYear"] = df["Date"].dt.dayofyear
 
+    df["DayOfYear"] = df["Date"].dt.dayofyear.astype(int)
     df["MonthYear"] = df["Date"].dt.strftime("%b %Y")
-    df["MonthYearNumber"] = df["Year"] * 100 + df["Month"]
-    df["CalendarMonthIndex"] = df["Year"] * 12 + df["Month"]
-    df["CalendarQuarterIndex"] = df["Year"] * 4 + df["Quarter"]
+    df["MonthYearNumber"] = (df["Year"] * 100 + df["Month"]).astype(int)
 
-    weekday = df["Date"].dt.weekday
-    df["DayOfWeek"] = (weekday + 1) % 7
+    # Indexes (monotonic but not "dense from 0" across multiple years – consistent with original intent)
+    df["CalendarMonthIndex"] = (df["Year"] * 12 + df["Month"]).astype(int)
+    df["CalendarQuarterIndex"] = (df["Year"] * 4 + df["Quarter"]).astype(int)
+
+    # Day-of-week conventions (kept compatible with your existing formula)
+    weekday = df["Date"].dt.weekday  # 0=Mon..6=Sun
+    df["DayOfWeek"] = ((weekday + 1) % 7).astype(int)  # 0=Sun, 1=Mon, ... 6=Sat
     df["IsWeekend"] = df["DayOfWeek"].isin([0, 6]).astype(int)
     df["IsBusinessDay"] = (df["IsWeekend"] == 0).astype(int)
 
-    iso = df["Date"].dt.isocalendar()
-    df["WeekOfYearISO"] = iso.week.astype(int)
-    df["ISOYear"] = iso.year.astype(int)
+    # Month start/end (fast)
+    df["MonthStartDate"] = df["Date"].values.astype("datetime64[M]")
+    df["MonthEndDate"] = (df["MonthStartDate"] + pd.offsets.MonthEnd(1)).dt.normalize()
 
-    df["QuarterStartDate"] = pd.to_datetime(
-        df["Year"].astype(str)
-        + "-"
-        + ((df["Quarter"] - 1) * 3 + 1).astype(str).str.zfill(2)
-        + "-01"
-    )
-    df["QuarterEndDate"] = df["QuarterStartDate"] + pd.offsets.QuarterEnd(0)
+    # Quarter start/end (clean + fast)
+    qperiod = df["Date"].dt.to_period("Q")
+    df["QuarterStartDate"] = qperiod.dt.start_time.dt.normalize()
+    df["QuarterEndDate"] = qperiod.dt.end_time.dt.normalize()
 
     df["IsMonthStart"] = (df["Day"] == 1).astype(int)
     df["IsMonthEnd"] = df["Date"].dt.is_month_end.astype(int)
@@ -128,60 +173,54 @@ def generate_date_table(start_date, end_date, first_fy_month):
     df["QuarterYear"] = "Q" + df["Quarter"].astype(str) + " " + df["Year"].astype(str)
     df["WeekOfMonth"] = ((df["Day"] - 1) // 7 + 1).astype(int)
 
-    df["WeekStartDate"] = df["Date"] - pd.to_timedelta(df["Date"].dt.weekday, unit="D")
-    df["WeekEndDate"] = df["WeekStartDate"] + pd.Timedelta(days=6)
+    # ISO week fields
+    iso = df["Date"].dt.isocalendar()
+    df["WeekOfYearISO"] = iso.week.astype(int)
+    df["ISOYear"] = iso.year.astype(int)
 
-    biz = df.loc[df["IsBusinessDay"] == 1, ["Date"]].rename(columns={"Date": "BizDate"})
+    # Week start/end (Monday..Sunday)
+    df["WeekStartDate"] = (df["Date"] - pd.to_timedelta(df["Date"].dt.weekday, unit="D")).dt.normalize()
+    df["WeekEndDate"] = (df["WeekStartDate"] + pd.Timedelta(days=6)).dt.normalize()
 
-    df = pd.merge_asof(
-        df.sort_values("Date"),
-        biz.assign(NextBD=biz["BizDate"]),
-        left_on="Date",
-        right_on="BizDate",
-        direction="forward"
-    ).drop(columns=["BizDate"])
-    df.rename(columns={"NextBD": "NextBusinessDay"}, inplace=True)
+    # Next/Previous Business Day (vectorized, replaces merge_asof)
+    # Semantics preserved: if Date is a business day, Next/Prev = itself.
+    biz_dates = df.loc[df["IsBusinessDay"] == 1, "Date"].to_numpy()
+    date_vals = df["Date"].to_numpy()
 
-    df = pd.merge_asof(
-        df,
-        biz.sort_values("BizDate").assign(PrevBD=biz["BizDate"]),
-        left_on="Date",
-        right_on="BizDate",
-        direction="backward"
-    ).drop(columns=["BizDate"])
-    df.rename(columns={"PrevBD": "PreviousBusinessDay"}, inplace=True)
+    if biz_dates.size > 0:
+        idx_next = np.searchsorted(biz_dates, date_vals, side="left")
+        idx_next = np.clip(idx_next, 0, biz_dates.size - 1)
+        df["NextBusinessDay"] = pd.to_datetime(biz_dates[idx_next]).normalize()
 
-    df["FiscalYearStartYear"] = np.where(
-        df["Month"] >= fy_start_month, df["Year"], df["Year"] - 1
-    )
+        idx_prev = np.searchsorted(biz_dates, date_vals, side="right") - 1
+        idx_prev = np.clip(idx_prev, 0, biz_dates.size - 1)
+        df["PreviousBusinessDay"] = pd.to_datetime(biz_dates[idx_prev]).normalize()
+    else:
+        df["NextBusinessDay"] = df["Date"]
+        df["PreviousBusinessDay"] = df["Date"]
 
-    df["FiscalMonthNumber"] = ((df["Month"] - fy_start_month + 12) % 12) + 1
-    df["FiscalQuarterNumber"] = ((df["FiscalMonthNumber"] - 1) // 3 + 1)
+    # Fiscal calendar
+    fy_start_month = fiscal_start_month
 
-    df["FiscalYearBin"] = (
-        df["FiscalYearStartYear"].astype(str)
-        + "-"
-        + (df["FiscalYearStartYear"] + 1).astype(str)
-    )
+    df["FiscalYearStartYear"] = np.where(df["Month"] >= fy_start_month, df["Year"], df["Year"] - 1).astype(int)
+    df["FiscalMonthNumber"] = (((df["Month"] - fy_start_month + 12) % 12) + 1).astype(int)
+    df["FiscalQuarterNumber"] = (((df["FiscalMonthNumber"] - 1) // 3) + 1).astype(int)
 
+    df["FiscalYearBin"] = df["FiscalYearStartYear"].astype(str) + "-" + (df["FiscalYearStartYear"] + 1).astype(str)
     df["FiscalQuarterName"] = (
-        "Q" + df["FiscalQuarterNumber"].astype(str)
-        + " FY" + (df["FiscalYearStartYear"] + 1).astype(str)
+        "Q" + df["FiscalQuarterNumber"].astype(str) + " FY" + (df["FiscalYearStartYear"] + 1).astype(str)
     )
 
-    df["FiscalYearMonthNumber"] = df["FiscalYearStartYear"] * 12 + df["FiscalMonthNumber"]
-    df["FiscalYearQuarterNumber"] = df["FiscalYearStartYear"] * 4 + df["FiscalQuarterNumber"]
+    df["FiscalYearMonthNumber"] = (df["FiscalYearStartYear"] * 12 + df["FiscalMonthNumber"]).astype(int)
+    df["FiscalYearQuarterNumber"] = (df["FiscalYearStartYear"] * 4 + df["FiscalQuarterNumber"]).astype(int)
 
-    df["FiscalMonthIndex"] = df["FiscalYearStartYear"] * 12 + df["FiscalMonthNumber"]
-    df["FiscalQuarterIndex"] = df["FiscalYearStartYear"] * 4 + df["FiscalQuarterNumber"]
+    df["FiscalMonthIndex"] = (df["FiscalYearStartYear"] * 12 + df["FiscalMonthNumber"]).astype(int)
+    df["FiscalQuarterIndex"] = (df["FiscalYearStartYear"] * 4 + df["FiscalQuarterNumber"]).astype(int)
 
     df["FiscalYearStartDate"] = pd.to_datetime(
-        df["FiscalYearStartYear"].astype(str)
-        + "-"
-        + str(fy_start_month).zfill(2)
-        + "-01"
-    )
-    df["FiscalYearEndDate"] = df["FiscalYearStartDate"] + pd.DateOffset(years=1) - pd.Timedelta(days=1)
+        df["FiscalYearStartYear"].astype(str) + "-" + str(fy_start_month).zfill(2) + "-01"
+    ).dt.normalize()
+    df["FiscalYearEndDate"] = (df["FiscalYearStartDate"] + pd.DateOffset(years=1) - pd.Timedelta(days=1)).dt.normalize()
 
     fq_shift = (df["FiscalQuarterNumber"] - 1) * 3
     fq_year = df["FiscalYearStartDate"].dt.year + ((df["FiscalYearStartDate"].dt.month + fq_shift - 1) // 12)
@@ -189,32 +228,28 @@ def generate_date_table(start_date, end_date, first_fy_month):
 
     df["FiscalQuarterStartDate"] = pd.to_datetime(
         fq_year.astype(str) + "-" + fq_month.astype(str).str.zfill(2) + "-01"
-    )
-    df["FiscalQuarterEndDate"] = df["FiscalQuarterStartDate"] + pd.DateOffset(months=3) - pd.Timedelta(days=1)
+    ).dt.normalize()
+    df["FiscalQuarterEndDate"] = (
+        df["FiscalQuarterStartDate"] + pd.DateOffset(months=3) - pd.Timedelta(days=1)
+    ).dt.normalize()
 
     df["IsFiscalYearStart"] = (df["Date"] == df["FiscalYearStartDate"]).astype(int)
     df["IsFiscalYearEnd"] = (df["Date"] == df["FiscalYearEndDate"]).astype(int)
     df["IsFiscalQuarterStart"] = (df["Date"] == df["FiscalQuarterStartDate"]).astype(int)
     df["IsFiscalQuarterEnd"] = (df["Date"] == df["FiscalQuarterEndDate"]).astype(int)
 
-    df["FiscalYear"] = np.where(
-        df["Month"] < fy_start_month, df["Year"], df["Year"] + 1
-    ).astype(int)
-
+    df["FiscalYear"] = np.where(df["Month"] < fy_start_month, df["Year"], df["Year"] + 1).astype(int)
     df["FiscalYearLabel"] = "FY " + df["FiscalYear"].astype(str)
 
-    today = pd.Timestamp.today().normalize()
-    df["IsToday"] = (df["Date"] == today).astype(int)
-    df["IsCurrentYear"] = (df["Year"] == today.year).astype(int)
-    df["IsCurrentMonth"] = ((df["Year"] == today.year) & (df["Month"] == today.month)).astype(int)
+    # Deterministic "current" flags relative to as_of_date
+    df["IsToday"] = (df["Date"] == as_of_date).astype(int)
+    df["IsCurrentYear"] = (df["Year"] == as_of_date.year).astype(int)
+    df["IsCurrentMonth"] = ((df["Year"] == as_of_date.year) & (df["Month"] == as_of_date.month)).astype(int)
+    current_quarter = (as_of_date.month - 1) // 3 + 1
+    df["IsCurrentQuarter"] = ((df["Year"] == as_of_date.year) & (df["Quarter"] == current_quarter)).astype(int)
+    df["CurrentDayOffset"] = (df["Date"] - as_of_date).dt.days.astype(int)
 
-    current_quarter = (today.month - 1) // 3 + 1
-    df["IsCurrentQuarter"] = ((df["Year"] == today.year) & (df["Quarter"] == current_quarter)).astype(int)
-    df["CurrentDayOffset"] = (df["Date"] - today).dt.days
-    
-    date_cols = df.select_dtypes(include="datetime").columns
-    df[date_cols] = df[date_cols].apply(lambda col: pd.to_datetime(col).dt.date)
-
+    # Stable column ordering (full superset; caller can subset)
     df = df[CALENDAR_COLUMNS + ISO_COLUMNS + FISCAL_COLUMNS]
     return df
 
@@ -223,39 +258,89 @@ def generate_date_table(start_date, end_date, first_fy_month):
 # PIPELINE WRAPPER
 # ---------------------------------------------------------
 
-def run_dates(cfg, parquet_folder: Path):
+def _normalize_override_dates(dates_cfg: Dict) -> Dict:
+    """
+    Supports either:
+      dates.override: { dates: {start,end} }
+    or:
+      dates.override: { start,end }
+    """
+    override = (dates_cfg or {}).get("override", {}) or {}
+    if isinstance(override, dict) and isinstance(override.get("dates"), dict):
+        return override["dates"] or {}
+    return override if isinstance(override, dict) else {}
 
+
+def _require_start_end(raw_start: Optional[str], raw_end: Optional[str]) -> Tuple[pd.Timestamp, pd.Timestamp]:
+    if not raw_start or not raw_end:
+        raise ValueError(
+            "Dates config is missing start/end. Provide defaults.dates.start/end "
+            "or set dates.override.dates.start/end."
+        )
+    return pd.to_datetime(raw_start), pd.to_datetime(raw_end)
+
+
+def run_dates(cfg: Dict, parquet_folder: Path) -> None:
     out_path = parquet_folder / "dates.parquet"
-    dates_cfg = cfg["dates"]
-    defaults_dates = cfg.get("defaults", {}).get("dates") or cfg.get("_defaults", {}).get("dates")
+
+    if "dates" not in cfg:
+        raise KeyError("Missing required config section: 'dates'")
+
+    dates_cfg = cfg["dates"] or {}
+
+    defaults_dates = (
+        (cfg.get("defaults", {}) or {}).get("dates")
+        or (cfg.get("_defaults", {}) or {}).get("dates")
+        or {}
+    )
 
     version_cfg = {**dates_cfg, "global_dates": defaults_dates}
 
     force = dates_cfg.get("_force_regenerate", False)
-
     if not force and not should_regenerate("dates", version_cfg, out_path):
         skip("Dates up-to-date; skipping.")
         return
 
-    override = dates_cfg.get("override", {}).get("dates", {})
-    raw_start = pd.to_datetime(
-        override.get("start") or defaults_dates.get("start")
-    )
-    raw_end = pd.to_datetime(
-        override.get("end") or defaults_dates.get("end")
-    )
+    override_dates = _normalize_override_dates(dates_cfg)
 
-    # Expand to full years + buffer
-    start_date = pd.Timestamp(raw_start.year - 1, 1, 1)
-    end_date = pd.Timestamp(raw_end.year + 1, 12, 31)
+    raw_start = override_dates.get("start") or defaults_dates.get("start")
+    raw_end = override_dates.get("end") or defaults_dates.get("end")
+    raw_start_ts, raw_end_ts = _require_start_end(raw_start, raw_end)
 
+    # Expand to full years + buffer (default 1 year)
+    buffer_years = int(dates_cfg.get("buffer_years", 1))
+    start_date = pd.Timestamp(raw_start_ts.year - buffer_years, 1, 1)
+    end_date = pd.Timestamp(raw_end_ts.year + buffer_years, 12, 31)
 
-    fiscal_start_month = dates_cfg.get("fiscal_month_offset", 5)
+    fiscal_start_month = int(dates_cfg.get("fiscal_start_month") or dates_cfg.get("fiscal_month_offset", 5))
+
+    # Deterministic "as of" (default: raw_end, can be overridden)
+    as_of_date = dates_cfg.get("as_of_date") or str(raw_end_ts.date())
+
+    # Parquet options (optional keys; safe defaults)
+    compression = dates_cfg.get("parquet_compression", "snappy")
+    compression_level = dates_cfg.get("parquet_compression_level", None)
+    force_date32 = bool(dates_cfg.get("force_date32", True))
 
     with stage("Generating Dates"):
-        df = generate_date_table(start_date, end_date, fiscal_start_month)
-        df = df[resolve_date_columns(dates_cfg)]
-        df.to_parquet(out_path, index=False)
+        df = generate_date_table(
+            start_date,
+            end_date,
+            fiscal_start_month,
+            as_of_date=as_of_date,
+        )
+
+        cols = resolve_date_columns(dates_cfg)
+        df = df[cols]
+
+        # Write so Power Query sees Date (Arrow date32) without PQ transforms
+        write_parquet_with_date32(
+            df,
+            out_path,
+            compression=compression,
+            compression_level=compression_level,
+            force_date32=force_date32,
+        )
 
     save_version("dates", version_cfg, out_path)
     info(f"Dates dimension written: {out_path}")

--- a/src/dimensions/promotions.py
+++ b/src/dimensions/promotions.py
@@ -1,226 +1,412 @@
 # ---------------------------------------------------------
-#  PROMOTIONS DIMENSION (PIPELINE READY – FIXED)
+#  PROMOTIONS DIMENSION (PIPELINE READY – OPTIMIZED)
+#  + Writes StartDate/EndDate as Arrow date32 (if pyarrow available)
+#    so Power Query imports them as Date (not DateTime).
 # ---------------------------------------------------------
 
-import pandas as pd
-import numpy as np
-from datetime import datetime, timedelta
+from __future__ import annotations
+
+from datetime import timedelta
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
 
 from src.utils.logging_utils import info, skip, stage
 from src.versioning.version_store import should_regenerate, save_version
 
 
 # ---------------------------------------------------------
-#  PROMOTION GENERATOR (SEMANTIC + SCALABLE)
+#  CONSTANTS
+# ---------------------------------------------------------
+
+PROMO_TYPES = {
+    "Holiday": "Holiday Discount",
+    "Seasonal": "Seasonal Discount",
+    "Clearance": "Clearance",
+    "Limited": "Limited Time",
+    "NoDiscount": "No Discount",
+}
+
+CATEGORIES = ["Store", "Online", "Region"]
+
+# name, start_mmdd, end_mmdd, discount_min, discount_max
+HOLIDAYS: List[Tuple[str, str, str, float, float]] = [
+    ("Black Friday",   "11-25", "11-30", 0.20, 0.70),
+    ("Cyber Monday",   "11-28", "12-02", 0.15, 0.50),
+    ("Christmas",      "12-10", "12-31", 0.20, 0.60),
+    ("New Year",       "12-26", "01-05", 0.10, 0.40),
+    ("Back-to-School", "07-01", "09-15", 0.05, 0.25),
+    ("Easter",         "03-20", "04-10", 0.05, 0.30),
+    ("Diwali",         "10-01", "11-15", 0.10, 0.50),
+]
+
+# Seasonal name -> (start_month, end_month) (end may wrap to next year)
+SEASON_WINDOWS: Dict[str, Tuple[int, int]] = {
+    "Spring Clearance": (2, 4),
+    "Summer Sale": (5, 8),
+    "Autumn Sale": (9, 10),
+    "Winter Sale": (11, 1),           # wraps year
+    "Mid-Season Discount": (3, 9),
+}
+
+
+# ---------------------------------------------------------
+#  PARQUET WRITER: FORCE DATE TYPES FOR POWER QUERY
+# ---------------------------------------------------------
+
+def _infer_datetime_cols(df: pd.DataFrame) -> List[str]:
+    return [c for c in df.columns if pd.api.types.is_datetime64_any_dtype(df[c])]
+
+
+def _write_parquet_with_date32(
+    df: pd.DataFrame,
+    out_path: Path,
+    *,
+    compression: str = "snappy",
+    compression_level: Optional[int] = None,
+    force_date32: bool = True,
+) -> None:
+    """
+    Write Parquet so datetime64 columns are stored as Arrow date32.
+    Power Query usually imports Arrow DATE as Date (not DateTime).
+
+    Fallback:
+      - If pyarrow is unavailable and force_date32 is True,
+        convert datetime cols to python date objects (object dtype) just for writing.
+    """
+    dt_cols = _infer_datetime_cols(df)
+
+    if not dt_cols:
+        df.to_parquet(out_path, index=False)
+        return
+
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except Exception:
+        if force_date32:
+            df2 = df.copy()
+            for c in dt_cols:
+                df2[c] = pd.to_datetime(df2[c]).dt.date
+            df2.to_parquet(out_path, index=False)
+        else:
+            df.to_parquet(out_path, index=False)
+        return
+
+    # Build Arrow table and cast datetime cols to date32
+    table = pa.Table.from_pandas(df, preserve_index=False)
+
+    fields = []
+    dt_cols_set = set(dt_cols)
+    for f in table.schema:
+        if f.name in dt_cols_set:
+            fields.append(pa.field(f.name, pa.date32()))
+        else:
+            fields.append(f)
+
+    table = table.cast(pa.schema(fields), safe=False)
+
+    kwargs = {"compression": compression}
+    if compression_level is not None:
+        kwargs["compression_level"] = compression_level
+
+    pq.write_table(table, str(out_path), **kwargs)
+
+
+# ---------------------------------------------------------
+#  HELPERS
+# ---------------------------------------------------------
+
+def _mmdd(mmdd: str, year: int) -> pd.Timestamp:
+    m, d = map(int, mmdd.split("-"))
+    return pd.Timestamp(year=year, month=m, day=d)
+
+
+def _valid_window(s: Optional[pd.Timestamp], e: Optional[pd.Timestamp]) -> bool:
+    return s is not None and e is not None and s < e
+
+
+def _build_year_windows(
+    start: pd.Timestamp, end: pd.Timestamp
+) -> Tuple[List[int], Dict[int, Tuple[pd.Timestamp, pd.Timestamp]]]:
+    start = pd.to_datetime(start).normalize()
+    end = pd.to_datetime(end).normalize()
+    if end < start:
+        raise ValueError(f"Promotions: end < start ({end.date()} < {start.date()})")
+
+    years = list(range(start.year, end.year + 1))
+    windows: Dict[int, Tuple[pd.Timestamp, pd.Timestamp]] = {}
+    for y in years:
+        ys = max(pd.Timestamp(f"{y}-01-01"), start)
+        ye = min(pd.Timestamp(f"{y}-12-31"), end)
+        windows[y] = (ys, ye)
+    return years, windows
+
+
+def _clamp_to_year_window(
+    dt: pd.Timestamp, year_windows: Dict[int, Tuple[pd.Timestamp, pd.Timestamp]]
+) -> Optional[pd.Timestamp]:
+    ws_we = year_windows.get(int(dt.year))
+    if not ws_we:
+        return None
+    ws, we = ws_we
+    if dt < ws:
+        return ws
+    if dt > we:
+        return we
+    return dt
+
+
+def _normalize_override_dates(promo_cfg: Dict) -> Dict:
+    """
+    Supports either:
+      promotions.override: { dates: {start,end} }
+    or:
+      promotions.override: { start,end }
+    """
+    override = (promo_cfg or {}).get("override", {}) or {}
+    if isinstance(override, dict) and isinstance(override.get("dates"), dict):
+        return override["dates"] or {}
+    return override if isinstance(override, dict) else {}
+
+
+def _pick_seed(promo_cfg: Dict) -> int:
+    override = (promo_cfg or {}).get("override", {}) or {}
+    seed = promo_cfg.get("seed", None)
+    if seed is None:
+        seed = override.get("seed", 42)
+    return int(seed)
+
+
+def _discount(rng: np.random.Generator, lo: float, hi: float) -> float:
+    return float(np.round(rng.uniform(lo, hi), 2))
+
+
+def _category(rng: np.random.Generator) -> str:
+    return str(rng.choice(CATEGORIES))
+
+
+def _seasonal_start_date(rng: np.random.Generator, y: int, start_m: int, end_m: int) -> pd.Timestamp:
+    # window wraps year
+    if start_m <= end_m:
+        m = int(rng.integers(start_m, end_m + 1))
+        year_for_start = y
+    else:
+        months = list(range(start_m, 13)) + list(range(1, end_m + 1))
+        m = int(rng.choice(months))
+        year_for_start = y if m >= start_m else y + 1
+
+    day = int(rng.integers(1, 25))
+    return pd.Timestamp(year=year_for_start, month=m, day=day)
+
+
+def _random_start_date(rng: np.random.Generator, y: int) -> pd.Timestamp:
+    m = int(rng.integers(1, 13))
+    d = int(rng.integers(1, 25))
+    return pd.Timestamp(year=y, month=m, day=d)
+
+
+# ---------------------------------------------------------
+#  PROMOTION GENERATOR
 # ---------------------------------------------------------
 
 def generate_promotions_catalog(
-    years,
-    year_windows,
-    num_seasonal=20,
-    num_clearance=8,
-    num_limited=12,
-    seed=42
-):
+    *,
+    years: List[int],
+    year_windows: Dict[int, Tuple[pd.Timestamp, pd.Timestamp]],
+    num_seasonal: int = 20,
+    num_clearance: int = 8,
+    num_limited: int = 12,
+    seed: int = 42,
+) -> pd.DataFrame:
+    """
+    Returns columns (UNCHANGED):
+      PromotionKey, PromotionLabel, PromotionName, PromotionDescription,
+      DiscountPct, PromotionType, PromotionCategory, StartDate, EndDate
+    """
     if not years:
         raise ValueError("Promotions: No years provided.")
+    if not year_windows:
+        raise ValueError("Promotions: year_windows is empty.")
 
-    np.random.seed(seed)
+    rng = np.random.default_rng(int(seed))
+    rows: List[Dict] = []
 
-    # -----------------------------------------------------
-    # Helpers
-    # -----------------------------------------------------
-    def clamp(dt):
-        ws, we = year_windows.get(dt.year, (None, None))
-        if ws is None:
-            return None
-        return max(ws, min(dt, we))
-
-    def valid(s, e):
-        return s is not None and e is not None and s < e
-
-    def mmdd(mmdd, y):
-        m, d = map(int, mmdd.split("-"))
-        return datetime(y, m, d)
-
-    # -----------------------------------------------------
-    # Promotion Metadata
-    # -----------------------------------------------------
-    PROMO_TYPES = {
-        "Holiday": "Holiday Discount",
-        "Seasonal": "Seasonal Discount",
-        "Clearance": "Clearance",
-        "Limited": "Limited Time",
-        "NoDiscount": "No Discount"
-    }
-
-    CATEGORIES = ["Store", "Online", "Region"]
-
-    # -----------------------------------------------------
-    # HOLIDAYS (DETERMINISTIC – ONE PER YEAR)
-    # -----------------------------------------------------
-    HOLIDAYS = [
-        ("Black Friday",   "11-25", "11-30", 0.20, 0.70),
-        ("Cyber Monday",   "11-28", "12-02", 0.15, 0.50),
-        ("Christmas",      "12-10", "12-31", 0.20, 0.60),
-        ("New Year",       "12-26", "01-05", 0.10, 0.40),
-        ("Back-to-School", "07-01", "09-15", 0.05, 0.25),
-        ("Easter",         "03-20", "04-10", 0.05, 0.30),
-        ("Diwali",         "10-01", "11-15", 0.10, 0.50),
-    ]
-
-    holiday_rows = []
-
+    # Holidays
     for y in years:
         for name, s_mmdd, e_mmdd, dmin, dmax in HOLIDAYS:
-            s = mmdd(s_mmdd, y)
+            s = _mmdd(s_mmdd, y)
+
             e_month = int(e_mmdd.split("-")[0])
             e_year = y + 1 if e_month < s.month else y
-            e = mmdd(e_mmdd, e_year)
+            e = _mmdd(e_mmdd, e_year)
 
-            s, e = clamp(s), clamp(e)
-            if not valid(s, e):
+            s = _clamp_to_year_window(s, year_windows)
+            e = _clamp_to_year_window(e, year_windows)
+
+            if not _valid_window(s, e):
                 continue
 
-            holiday_rows.append({
-                "TypeGroup": "Holiday",
-                "SeasonType": name,
-                "Year": y,
-                "PromotionName": f"{name} {y}",
-                "PromotionDescription": f"{name} {y} Promotion",
-                "DiscountPct": round(np.random.uniform(dmin, dmax), 2),
-                "PromotionType": PROMO_TYPES["Holiday"],
-                "PromotionCategory": np.random.choice(CATEGORIES),
-                "StartDate": pd.Timestamp(s),
-                "EndDate": pd.Timestamp(e),
-            })
+            rows.append(
+                {
+                    "TypeGroup": "Holiday",
+                    "SeasonType": name,
+                    "Year": y,
+                    "PromotionName": f"{name} {y}",
+                    "PromotionDescription": f"{name} {y} Promotion",
+                    "DiscountPct": _discount(rng, dmin, dmax),
+                    "PromotionType": PROMO_TYPES["Holiday"],
+                    "PromotionCategory": _category(rng),
+                    "StartDate": pd.Timestamp(s),
+                    "EndDate": pd.Timestamp(e),
+                }
+            )
 
-    # -----------------------------------------------------
-    # SEASONAL (BOUNDED RANDOMNESS)
-    # -----------------------------------------------------
-    SEASON_WINDOWS = {
-        "Spring Clearance": (2, 4),
-        "Summer Sale": (5, 8),
-        "Autumn Sale": (9, 10),
-        "Winter Sale": (11, 1),
-        "Mid-Season Discount": (3, 9),
-    }
+    # Seasonal
+    for _ in range(int(num_seasonal)):
+        y = int(rng.choice(years))
+        season_name = str(rng.choice(list(SEASON_WINDOWS.keys())))
+        sm, em = SEASON_WINDOWS[season_name]
 
-    def seasonal_window(y, start_m, end_m):
-        if start_m <= end_m:
-            m = np.random.randint(start_m, end_m + 1)
-            year = y
-        else:
-            m = np.random.choice([*range(start_m, 13), *range(1, end_m + 1)])
-            year = y if m >= start_m else y + 1
+        start = _seasonal_start_date(rng, y, sm, em)
+        end = start + timedelta(days=int(rng.integers(10, 60)))
 
-        start = datetime(year, m, np.random.randint(1, 25))
-        end = start + timedelta(days=np.random.randint(10, 60))
-        return clamp(start), clamp(end)
+        start = _clamp_to_year_window(start, year_windows)
+        end = _clamp_to_year_window(end, year_windows)
 
-    seasonal_rows = []
+        if not _valid_window(start, end):
+            continue
 
-    for _ in range(num_seasonal):
-        y = np.random.choice(years)
-        name = np.random.choice(list(SEASON_WINDOWS.keys()))
-        sm, em = SEASON_WINDOWS[name]
-        s, e = seasonal_window(y, sm, em)
-        if valid(s, e):
-            seasonal_rows.append({
+        rows.append(
+            {
                 "TypeGroup": "Seasonal",
-                "SeasonType": name,
+                "SeasonType": season_name,
                 "Year": y,
-                "StartDate": pd.Timestamp(s),
-                "EndDate": pd.Timestamp(e),
-                "DiscountPct": round(np.random.uniform(0.05, 0.30), 2),
+                "PromotionName": None,
+                "PromotionDescription": None,
+                "DiscountPct": _discount(rng, 0.05, 0.30),
                 "PromotionType": PROMO_TYPES["Seasonal"],
-                "PromotionCategory": np.random.choice(CATEGORIES),
-            })
+                "PromotionCategory": _category(rng),
+                "StartDate": pd.Timestamp(start),
+                "EndDate": pd.Timestamp(end),
+            }
+        )
 
-    # -----------------------------------------------------
-    # CLEARANCE / LIMITED (FREE RANDOMNESS)
-    # -----------------------------------------------------
-    def random_window(y, min_d, max_d):
-        start = datetime(y, np.random.randint(1, 13), np.random.randint(1, 25))
-        end = start + timedelta(days=np.random.randint(min_d, max_d))
-        return clamp(start), clamp(end)
+    # Clearance
+    for _ in range(int(num_clearance)):
+        y = int(rng.choice(years))
+        start = _random_start_date(rng, y)
+        end = start + timedelta(days=int(rng.integers(3, 25)))
 
-    clearance_rows, limited_rows = [], []
+        start = _clamp_to_year_window(start, year_windows)
+        end = _clamp_to_year_window(end, year_windows)
 
-    for _ in range(num_clearance):
-        y = np.random.choice(years)
-        s, e = random_window(y, 3, 25)
-        if valid(s, e):
-            clearance_rows.append({
+        if not _valid_window(start, end):
+            continue
+
+        rows.append(
+            {
                 "TypeGroup": "Clearance",
                 "SeasonType": "Clearance",
                 "Year": y,
-                "StartDate": pd.Timestamp(s),
-                "EndDate": pd.Timestamp(e),
-                "DiscountPct": round(np.random.uniform(0.30, 0.70), 2),
+                "PromotionName": None,
+                "PromotionDescription": None,
+                "DiscountPct": _discount(rng, 0.30, 0.70),
                 "PromotionType": PROMO_TYPES["Clearance"],
-                "PromotionCategory": np.random.choice(CATEGORIES),
-            })
+                "PromotionCategory": _category(rng),
+                "StartDate": pd.Timestamp(start),
+                "EndDate": pd.Timestamp(end),
+            }
+        )
 
-    for _ in range(num_limited):
-        y = np.random.choice(years)
-        s, e = random_window(y, 1, 15)
-        if valid(s, e):
-            limited_rows.append({
+    # Limited
+    for _ in range(int(num_limited)):
+        y = int(rng.choice(years))
+        start = _random_start_date(rng, y)
+        end = start + timedelta(days=int(rng.integers(1, 15)))
+
+        start = _clamp_to_year_window(start, year_windows)
+        end = _clamp_to_year_window(end, year_windows)
+
+        if not _valid_window(start, end):
+            continue
+
+        rows.append(
+            {
                 "TypeGroup": "Limited",
                 "SeasonType": "Limited Time",
                 "Year": y,
-                "StartDate": pd.Timestamp(s),
-                "EndDate": pd.Timestamp(e),
-                "DiscountPct": round(np.random.uniform(0.05, 0.35), 2),
+                "PromotionName": None,
+                "PromotionDescription": None,
+                "DiscountPct": _discount(rng, 0.05, 0.35),
                 "PromotionType": PROMO_TYPES["Limited"],
-                "PromotionCategory": np.random.choice(CATEGORIES),
-            })
+                "PromotionCategory": _category(rng),
+                "StartDate": pd.Timestamp(start),
+                "EndDate": pd.Timestamp(end),
+            }
+        )
 
-    # -----------------------------------------------------
-    # FINAL ASSEMBLY
-    # -----------------------------------------------------
-    df = pd.DataFrame(
-        holiday_rows + seasonal_rows + clearance_rows + limited_rows
+    if not rows:
+        raise ValueError("Promotions: No promotions could be generated (check date windows and config).")
+
+    df = pd.DataFrame(rows)
+
+    # Stable ordering
+    df = df.sort_values(["TypeGroup", "Year", "SeasonType", "StartDate"]).reset_index(drop=True)
+
+    # Number + label non-holiday promos
+    mask_non_holiday = df["TypeGroup"] != "Holiday"
+    if mask_non_holiday.any():
+        grp = df.loc[mask_non_holiday].groupby(["Year", "TypeGroup", "SeasonType"], sort=False)
+        local_index = grp.cumcount() + 1
+        df.loc[mask_non_holiday, "LocalIndex"] = local_index.to_numpy()
+
+        df.loc[mask_non_holiday, "PromotionName"] = (
+            df.loc[mask_non_holiday, "SeasonType"].astype(str)
+            + " "
+            + df.loc[mask_non_holiday, "Year"].astype(int).astype(str)
+            + " #"
+            + df.loc[mask_non_holiday, "LocalIndex"].astype(int).astype(str)
+        )
+        df.loc[mask_non_holiday, "PromotionDescription"] = (
+            df.loc[mask_non_holiday, "SeasonType"].astype(str)
+            + " for "
+            + df.loc[mask_non_holiday, "Year"].astype(int).astype(str)
+        )
+
+    df.loc[~mask_non_holiday, "LocalIndex"] = None
+
+    # Append "No Discount"
+    min_year = min(years)
+    max_year = max(years)
+    no_discount = pd.DataFrame(
+        [
+            {
+                "TypeGroup": "NoDiscount",
+                "SeasonType": "NoDiscount",
+                "Year": min_year,
+                "PromotionName": "No Discount",
+                "PromotionDescription": "No Discount",
+                "DiscountPct": 0.0,
+                "PromotionType": PROMO_TYPES["NoDiscount"],
+                "PromotionCategory": "No Discount",
+                "StartDate": pd.Timestamp(year_windows[min_year][0]),
+                "EndDate": pd.Timestamp(year_windows[max_year][1]),
+                "LocalIndex": None,
+            }
+        ]
     )
 
-    numbered = []
-    for (y, tg, st), g in df[df["TypeGroup"] != "Holiday"].groupby(
-        ["Year", "TypeGroup", "SeasonType"]
-    ):
-        g = g.sort_values("StartDate").copy()
-        g["LocalIndex"] = range(1, len(g) + 1)
-        g["PromotionName"] = f"{st} {y} #" + g["LocalIndex"].astype(str)
-        g["PromotionDescription"] = f"{st} for {y}"
-        numbered.append(g)
+    final = pd.concat([df, no_discount], ignore_index=True)
 
-    holidays = df[df["TypeGroup"] == "Holiday"].copy()
-    holidays["LocalIndex"] = None
-
-    final = pd.concat([holidays] + numbered, ignore_index=True)
-
-    final = pd.concat([
-        final,
-        pd.DataFrame([{
-            "TypeGroup": "NoDiscount",
-            "SeasonType": "NoDiscount",
-            "Year": min(years),
-            "PromotionName": "No Discount",
-            "PromotionDescription": "No Discount",
-            "DiscountPct": 0.0,
-            "PromotionType": PROMO_TYPES["NoDiscount"],
-            "PromotionCategory": "No Discount",
-            "StartDate": year_windows[min(years)][0],
-            "EndDate": year_windows[max(years)][1],
-            "LocalIndex": None,
-        }])
-    ], ignore_index=True)
-
+    # Final ordering + keys
     final = final.sort_values("StartDate").reset_index(drop=True)
-    final["PromotionKey"] = final.index + 1
+    final["PromotionKey"] = (final.index + 1).astype(np.int64)
     final["PromotionLabel"] = final["PromotionKey"]
 
+    # Output schema (UNCHANGED)
     return final[
         [
             "PromotionKey",
@@ -237,49 +423,62 @@ def generate_promotions_catalog(
 
 
 # ---------------------------------------------------------
-#  PIPELINE ENTRYPOINT (UNCHANGED)
+#  PIPELINE ENTRYPOINT
 # ---------------------------------------------------------
 
-def run_promotions(cfg, parquet_folder: Path):
+def run_promotions(cfg: Dict, parquet_folder: Path) -> None:
     out_path = parquet_folder / "promotions.parquet"
 
-    promo_cfg = cfg["promotions"]
-    defaults_dates = cfg.get("defaults", {}).get("dates") or cfg.get("_defaults", {}).get("dates")
+    if not isinstance(cfg, dict) or "promotions" not in cfg:
+        raise KeyError("Missing required config section: 'promotions'")
+
+    promo_cfg = cfg["promotions"] or {}
+    defaults_dates = (cfg.get("defaults", {}) or {}).get("dates") or (cfg.get("_defaults", {}) or {}).get("dates")
+    if not defaults_dates or "start" not in defaults_dates or "end" not in defaults_dates:
+        raise ValueError("Promotions: missing defaults.dates.start/end (or _defaults.dates.start/end)")
 
     version_cfg = {**promo_cfg, "global_dates": defaults_dates}
 
-    force = promo_cfg.get("_force_regenerate", False)
-
+    force = bool(promo_cfg.get("_force_regenerate", False))
     if not force and not should_regenerate("promotions", version_cfg, out_path):
         skip("Promotions up-to-date; skipping.")
         return
 
-    override = promo_cfg.get("override", {}).get("dates")
-    if override and override.get("start") and override.get("end"):
-        start = pd.to_datetime(override["start"])
-        end = pd.to_datetime(override["end"])
+    override_dates = _normalize_override_dates(promo_cfg)
+
+    if override_dates.get("start") and override_dates.get("end"):
+        start = pd.to_datetime(override_dates["start"])
+        end = pd.to_datetime(override_dates["end"])
     else:
         start = pd.to_datetime(defaults_dates["start"])
         end = pd.to_datetime(defaults_dates["end"])
 
-    years = list(range(start.year, end.year + 1))
+    years, windows = _build_year_windows(start, end)
+    seed = _pick_seed(promo_cfg)
 
-    windows = {}
-    for y in years:
-        ys = max(pd.Timestamp(f"{y}-01-01"), start)
-        ye = min(pd.Timestamp(f"{y}-12-31"), end)
-        windows[y] = (ys, ye)
+    # Optional parquet settings (safe defaults)
+    compression = promo_cfg.get("parquet_compression", "snappy")
+    compression_level = promo_cfg.get("parquet_compression_level", None)
+    force_date32 = bool(promo_cfg.get("force_date32", True))
 
     with stage("Generating Promotions"):
         df = generate_promotions_catalog(
             years=years,
             year_windows=windows,
-            num_seasonal=promo_cfg.get("num_seasonal", 20),
-            num_clearance=promo_cfg.get("num_clearance", 8),
-            num_limited=promo_cfg.get("num_limited", 12),
-            seed=promo_cfg.get("override", {}).get("seed", 42),
+            num_seasonal=int(promo_cfg.get("num_seasonal", 20)),
+            num_clearance=int(promo_cfg.get("num_clearance", 8)),
+            num_limited=int(promo_cfg.get("num_limited", 12)),
+            seed=seed,
         )
-        df.to_parquet(out_path, index=False)
+
+        # Write with date32 for Power Query
+        _write_parquet_with_date32(
+            df,
+            out_path,
+            compression=str(compression),
+            compression_level=(int(compression_level) if compression_level is not None else None),
+            force_date32=force_date32,
+        )
 
     save_version("promotions", version_cfg, out_path)
     info(f"Promotions dimension written: {out_path}")

--- a/src/dimensions/static_loader.py
+++ b/src/dimensions/static_loader.py
@@ -1,7 +1,12 @@
-import pandas as pd
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
+import pandas as pd
 
 from src.utils import info, skip
+from src.utils.output_utils import write_parquet_with_date32
 from src.versioning import should_regenerate, save_version
 
 
@@ -9,14 +14,45 @@ def load_static_dimension(
     name: str,
     src_path: Path,
     output_path: Path,
-):
+    *,
+    # Date logic (Power Query friendly)
+    date_cols: Optional[Sequence[str]] = None,
+    cast_all_datetime: bool = False,
+    # Parquet options
+    compression: str = "snappy",
+    compression_level: Optional[int] = None,
+    force_date32: bool = True,
+) -> Tuple[pd.DataFrame, bool]:
     """
-    Load a static reference dimension by copying it as-is.
-    Returns: (DataFrame, regenerated: bool)
-    """
+    Load a static reference dimension from parquet and write it to output_path.
 
+    Returns: (DataFrame, regenerated: bool)
+
+    Date logic:
+      - Writes selected datetime columns as Arrow date32 when pyarrow is available,
+        so Power Query imports them as Date (not DateTime).
+      - If pyarrow isn't available and force_date32=True, falls back to python date
+        objects for selected columns during write.
+    """
+    src_path = Path(src_path)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not src_path.exists():
+        raise FileNotFoundError(f"Static dimension source not found: {src_path}")
+
+    stat = src_path.stat()
+
+    # Stronger version key: path + file fingerprint
     version_key = {
         "source": str(src_path),
+        "source_size": int(stat.st_size),
+        "source_mtime_ns": int(stat.st_mtime_ns),
+        "date_cols": list(date_cols) if date_cols is not None else None,
+        "cast_all_datetime": bool(cast_all_datetime),
+        "compression": str(compression),
+        "compression_level": (int(compression_level) if compression_level is not None else None),
+        "force_date32": bool(force_date32),
     }
 
     if not should_regenerate(name, version_key, output_path):
@@ -26,7 +62,17 @@ def load_static_dimension(
     info(f"Loading {name}")
 
     df = pd.read_parquet(src_path)
-    df.to_parquet(output_path, index=False)
+
+    # Write using shared utility for consistent Power Query behavior
+    write_parquet_with_date32(
+        df,
+        output_path,
+        date_cols=date_cols,
+        cast_all_datetime=cast_all_datetime,
+        compression=compression,
+        compression_level=compression_level,
+        force_date32=force_date32,
+    )
 
     save_version(name, version_key, output_path)
     return df, True

--- a/src/dimensions/stores.py
+++ b/src/dimensions/stores.py
@@ -1,154 +1,274 @@
 # ---------------------------------------------------------
-#  STORES DIMENSION (PIPELINE READY)
+#  STORES DIMENSION (PIPELINE READY – OPTIMIZED)
+#  - Robust config parsing (handles seed: null)
+#  - Avoids double-reading geography.parquet
+#  - Generates dates at day granularity (date-only)
+#  - Writes OpeningDate/ClosingDate as Arrow date32 via write_parquet_with_date32()
 # ---------------------------------------------------------
 
-import pandas as pd
-import numpy as np
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Dict, Optional, Union
 
-from src.utils.logging_utils import info, fail, skip, stage
+import numpy as np
+import pandas as pd
+
+from src.utils.logging_utils import info, skip, stage
+from src.utils.output_utils import write_parquet_with_date32
 from src.versioning.version_store import should_regenerate, save_version
-from src.engine.dimension_loader import load_dimension
 
 
 # ---------------------------------------------------------
-# ORIGINAL GENERATOR  (unchanged) :contentReference[oaicite:0]{index=0}
+# Constants (kept local for clarity)
+# ---------------------------------------------------------
+
+_STORE_TYPES = np.array(["Supermarket", "Convenience", "Online", "Hypermarket"], dtype=object)
+_STORE_STATUS = np.array(["Open", "Closed", "Renovating"], dtype=object)
+_CLOSE_REASONS = np.array(["Low Sales", "Lease Ended", "Renovation", "Moved Location"], dtype=object)
+
+_STORE_TYPES_P = np.array([0.50, 0.30, 0.10, 0.10], dtype=float)
+_STORE_STATUS_P = np.array([0.85, 0.10, 0.05], dtype=float)
+
+
+# ---------------------------------------------------------
+# Internals
+# ---------------------------------------------------------
+
+def _require_cfg(cfg: Dict) -> Dict:
+    if not isinstance(cfg, dict):
+        raise TypeError("cfg must be a dict")
+    stores = cfg.get("stores")
+    if not isinstance(stores, dict):
+        raise KeyError("Missing required config section: 'stores'")
+    return stores
+
+
+def _as_dict(x) -> Dict:
+    return x if isinstance(x, dict) else {}
+
+
+def _int_or(value, default: int) -> int:
+    """Safe int parsing: handles None, '', and non-numeric values."""
+    try:
+        if value is None or value == "":
+            return int(default)
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _pick_seed(cfg: Dict, store_cfg: Dict, fallback: int = 42) -> int:
+    """
+    Seed precedence (robust to nulls):
+      stores.override.seed -> stores.seed -> defaults.seed -> fallback
+    """
+    override = _as_dict(store_cfg.get("override"))
+    seed = override.get("seed")
+    if seed is None:
+        seed = store_cfg.get("seed")
+    if seed is None:
+        seed = _as_dict(cfg.get("defaults")).get("seed")
+    return _int_or(seed, fallback)
+
+
+def _as_date64d(x: Union[str, pd.Timestamp]) -> np.datetime64:
+    """Convert to numpy datetime64[D] (date-only)."""
+    ts = pd.to_datetime(x).normalize()
+    return np.datetime64(ts.date(), "D")
+
+
+def _rand_dates_d(
+    rng: np.random.Generator,
+    start_d: np.datetime64,
+    end_d: np.datetime64,
+    size: int,
+) -> np.ndarray:
+    """
+    Random date-only array in [start_d, end_d] inclusive.
+    Returns numpy datetime64[D].
+    """
+    if end_d < start_d:
+        raise ValueError(f"Invalid date range: {start_d}..{end_d}")
+
+    start_i = start_d.astype("int64")
+    end_i = end_d.astype("int64")
+
+    days = rng.integers(start_i, end_i + 1, size=size, dtype=np.int64)
+    return days.astype("datetime64[D]")
+
+
+def _geography_signature(keys: np.ndarray) -> Dict:
+    """
+    Lightweight signature so changes in geography trigger regeneration.
+    Uses row count + min/max GeographyKey.
+    """
+    if keys.size == 0:
+        return {"rows": 0, "min_key": None, "max_key": None}
+    return {
+        "rows": int(keys.size),
+        "min_key": int(keys.min()),
+        "max_key": int(keys.max()),
+    }
+
+
+# ---------------------------------------------------------
+# Generator
 # ---------------------------------------------------------
 
 def generate_store_table(
-    geography_parquet_path="./data/parquet_dims/geography.parquet",
-    num_stores=200,
-    opening_start="2018-01-01",
-    opening_end="2023-01-31",
-    closing_end="2025-12-31",
-    seed=42
-):
+    *,
+    geo_keys: np.ndarray,
+    num_stores: int = 200,
+    opening_start: str = "2018-01-01",
+    opening_end: str = "2023-01-31",
+    closing_end: str = "2025-12-31",
+    seed: int = 42,
+) -> pd.DataFrame:
     """
     Generate synthetic store dimension table.
-    GeographyKey comes from final DimGeography (parquet).
+
+    Output columns (unchanged):
+      StoreKey, StoreName, StoreType, Status, GeographyKey,
+      OpeningDate, ClosingDate, OpenFlag, SquareFootage, EmployeeCount,
+      StoreManager, Phone, StoreDescription, CloseReason
     """
-    rng = np.random.default_rng(seed)
+    num_stores = _int_or(num_stores, 200)
+    if num_stores <= 0:
+        raise ValueError(f"num_stores must be > 0, got {num_stores}")
 
-    # --------------------------------------------------------
-    # Load Geography
-    # --------------------------------------------------------
-    geo = pd.read_parquet(geography_parquet_path)
+    if not isinstance(geo_keys, np.ndarray) or geo_keys.size == 0:
+        raise ValueError("geo_keys must be a non-empty numpy array of GeographyKey values")
 
-    if "GeographyKey" not in geo.columns:
-        raise ValueError(
-            f"'GeographyKey' missing in geography parquet. "
-            f"Found: {list(geo.columns)}"
-        )
+    rng = np.random.default_rng(_int_or(seed, 42))
 
-    geo_keys = geo["GeographyKey"].astype(int).to_numpy()
-
-    # --------------------------------------------------------
     # Base structure
-    # --------------------------------------------------------
-    df = pd.DataFrame({"StoreKey": np.arange(1, num_stores + 1)})
+    store_key = np.arange(1, num_stores + 1, dtype=np.int64)
+    df = pd.DataFrame({"StoreKey": store_key})
 
-    df["StoreName"] = df["StoreKey"].map(lambda x: f"Store #{x:04d}")
+    # Vectorized names
+    key_str4 = pd.Series(store_key).astype(str).str.zfill(4)
+    df["StoreName"] = "Store #" + key_str4
+    df["StoreManager"] = "Manager " + key_str4
 
-    store_types = ["Supermarket", "Convenience", "Online", "Hypermarket"]
-    store_status = ["Open", "Closed", "Renovating"]
-    close_reasons = ["Low Sales", "Lease Ended", "Renovation", "Moved Location"]
+    # Categories
+    df["StoreType"] = rng.choice(_STORE_TYPES, size=num_stores, p=_STORE_TYPES_P)
+    df["Status"] = rng.choice(_STORE_STATUS, size=num_stores, p=_STORE_STATUS_P)
 
-    df["StoreType"] = rng.choice(store_types, num_stores, p=[0.5, 0.3, 0.1, 0.1])
-    df["Status"] = rng.choice(store_status, num_stores, p=[0.85, 0.10, 0.05])
-
-    # --------------------------------------------------------
     # GeographyKey assignment
-    # --------------------------------------------------------
-    df["GeographyKey"] = rng.choice(geo_keys, size=num_stores, replace=True)
+    df["GeographyKey"] = rng.choice(geo_keys.astype(np.int64), size=num_stores, replace=True)
 
-    # --------------------------------------------------------
-    # Opening Date
-    # --------------------------------------------------------
-    open_start_ts = pd.Timestamp(opening_start).value // 10**9
-    open_end_ts   = pd.Timestamp(opening_end).value   // 10**9
+    # Date generation at DAY granularity
+    open_start_d = _as_date64d(opening_start)
+    open_end_d = _as_date64d(opening_end)
+    close_end_d = _as_date64d(closing_end)
 
-    df["OpeningDate"] = pd.to_datetime(
-        rng.integers(open_start_ts, open_end_ts, num_stores),
-        unit="s"
-    )
+    opening_d = _rand_dates_d(rng, open_start_d, open_end_d, num_stores)
+    df["OpeningDate"] = pd.to_datetime(opening_d.astype("datetime64[ns]")).normalize()
 
-    # --------------------------------------------------------
-    # Closing Date (vectorized, schema-safe)
-    # --------------------------------------------------------
-    closing_cutoff_ts = pd.Timestamp(closing_end).value // 10**9
-
+    # ClosingDate only for Closed stores, always >= OpeningDate
     df["ClosingDate"] = pd.NaT
-    closed_mask = df["Status"] == "Closed"
+    closed_mask = (df["Status"].to_numpy() == "Closed")
 
     if closed_mask.any():
-        open_ts = df.loc[closed_mask, "OpeningDate"].astype("int64") // 10**9
-        df.loc[closed_mask, "ClosingDate"] = pd.to_datetime(
-            rng.integers(open_ts, closing_cutoff_ts),
-            unit="s"
-        )
+        open_days = opening_d.astype("int64")[closed_mask]  # days since epoch
+        close_end_day = close_end_d.astype("int64")
+        effective_end = np.maximum(open_days, close_end_day)
 
-    # --------------------------------------------------------
+        close_days = rng.integers(open_days, effective_end + 1, dtype=np.int64)
+        close_d = close_days.astype("datetime64[D]")
+        df.loc[closed_mask, "ClosingDate"] = pd.to_datetime(close_d.astype("datetime64[ns]")).normalize()
+
     # Additional attributes
-    # --------------------------------------------------------
-    df["OpenFlag"] = (df["Status"] == "Open").astype(int)
-    df["SquareFootage"] = rng.integers(2000, 10000, num_stores)
-    df["EmployeeCount"] = rng.integers(10, 120, num_stores)
+    df["OpenFlag"] = (df["Status"] == "Open").astype(np.int64)
+    df["SquareFootage"] = rng.integers(2000, 10000, size=num_stores, dtype=np.int64)
+    df["EmployeeCount"] = rng.integers(10, 120, size=num_stores, dtype=np.int64)
 
-    df["StoreManager"] = df["StoreKey"].map(lambda x: f"Manager {x:04d}")
-    df["Phone"] = df["StoreKey"].map(
-        lambda x: f"(555) {x % 900 + 100}-{x % 10000:04d}"
+    # Phone (vectorized)
+    first = (store_key % 900) + 100          # 100..999
+    second = store_key % 10000               # 0..9999
+    df["Phone"] = (
+        "(555) "
+        + pd.Series(first).astype(str).str.zfill(3)
+        + "-"
+        + pd.Series(second).astype(str).str.zfill(4)
     )
 
-    df["StoreDescription"] = (
-        df["StoreType"] + " located in GeographyKey " + df["GeographyKey"].astype(str)
-    )
+    df["StoreDescription"] = df["StoreType"].astype(str) + " located in GeographyKey " + df["GeographyKey"].astype(str)
 
-    df["CloseReason"] = np.where(
-        df["Status"] == "Closed",
-        rng.choice(close_reasons, size=num_stores),
-        ""
-    )
+    df["CloseReason"] = ""
+    if closed_mask.any():
+        df.loc[closed_mask, "CloseReason"] = rng.choice(_CLOSE_REASONS, size=int(closed_mask.sum()))
 
     return df
 
 
 # ---------------------------------------------------------
-#  PIPELINE ENTRYPOINT
+# Pipeline entrypoint
 # ---------------------------------------------------------
 
-def run_stores(cfg, parquet_folder: Path):
+def run_stores(cfg: Dict, parquet_folder: Path) -> None:
     """
-    Pipeline wrapper for store dimension generation.
-    Handles:
+    Pipeline wrapper for stores dimension generation.
     - version checks
-    - logging
-    - geography dim loading
-    - writing parquet
-    - version saving
+    - geography dependency signature
+    - Parquet write with Arrow date32 for OpeningDate/ClosingDate (Power Query Date)
     """
+    store_cfg = _require_cfg(cfg)
+
+    parquet_folder = Path(parquet_folder)
+    parquet_folder.mkdir(parents=True, exist_ok=True)
 
     out_path = parquet_folder / "stores.parquet"
+    geo_path = parquet_folder / "geography.parquet"
 
-    store_cfg = cfg["stores"]
-    force = store_cfg.get("_force_regenerate", False)
+    if not geo_path.exists():
+        raise FileNotFoundError(f"Missing geography parquet: {geo_path}")
 
-    if not force and not should_regenerate("stores", store_cfg, out_path):
+    force = bool(store_cfg.get("_force_regenerate", False))
+
+    # Load geography keys once (avoid re-read in generator)
+    geo = pd.read_parquet(geo_path, columns=["GeographyKey"])
+    if "GeographyKey" not in geo.columns:
+        raise ValueError("geography.parquet missing required column: GeographyKey")
+    geo_keys = geo["GeographyKey"].astype(np.int64).to_numpy()
+
+    version_cfg = {
+        **store_cfg,
+        "_geography_sig": _geography_signature(geo_keys),
+    }
+
+    if not force and not should_regenerate("stores", version_cfg, out_path):
         skip("Stores up-to-date; skipping.")
         return
 
-    geo_path = parquet_folder / "geography.parquet"
+    # Optional parquet settings
+    compression = store_cfg.get("parquet_compression", "snappy")
+    compression_level = store_cfg.get("parquet_compression_level", None)
+    force_date32 = bool(store_cfg.get("force_date32", True))
+
+    opening_cfg = _as_dict(store_cfg.get("opening"))
 
     with stage("Generating Stores"):
         df = generate_store_table(
-            geography_parquet_path=geo_path,
-            num_stores=store_cfg.get("num_stores", 200),
-            opening_start=store_cfg.get("opening", {}).get("start", "1995-01-01"),
-            opening_end=store_cfg.get("opening", {}).get("end", "2020-12-31"),
-            closing_end=store_cfg.get("closing_end", "2025-12-31"),
-            seed=store_cfg.get("override", {}).get("seed", 42),
+            geo_keys=geo_keys,
+            num_stores=_int_or(store_cfg.get("num_stores"), 200),
+            opening_start=opening_cfg.get("start") or "1995-01-01",
+            opening_end=opening_cfg.get("end") or "2020-12-31",
+            closing_end=store_cfg.get("closing_end") or "2025-12-31",
+            seed=_pick_seed(cfg, store_cfg, fallback=42),
         )
-        df.to_parquet(out_path, index=False)
 
-    save_version("stores", store_cfg, out_path)
-    
+        # Cast only the intended date fields to Arrow date32
+        write_parquet_with_date32(
+            df,
+            out_path,
+            date_cols=["OpeningDate", "ClosingDate"],
+            cast_all_datetime=False,
+            compression=str(compression),
+            compression_level=(int(compression_level) if compression_level is not None else None),
+            force_date32=force_date32,
+        )
+
+    save_version("stores", version_cfg, out_path)
     info(f"Stores dimension written: {out_path}")

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -1,44 +1,63 @@
+from __future__ import annotations
+
 import os
+import sys
 import time
+import atexit
+import threading
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any, Optional
 
 
-# Compute project root (top-level folder)
+# ============================================================================
+# PROJECT ROOT + PATH SHORTENING
+# ============================================================================
+# Kept identical semantics: project root is the top-level folder.
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
-def short_path(p):
+
+def short_path(p: Any) -> Any:
+    """
+    If p is a path under PROJECT_ROOT, return a relative path string.
+    Otherwise return the last component (name), matching previous behavior.
+    """
     if not p:
         return p
-    p = Path(p)
     try:
-        return str(p.relative_to(PROJECT_ROOT))
+        pth = Path(p)
     except Exception:
-        return p.name  # last component only
+        return p
+
+    try:
+        return str(pth.relative_to(PROJECT_ROOT))
+    except Exception:
+        # Preserve previous fallback behavior: only last component
+        return pth.name
 
 
-def _shorten_path_in_msg(msg: str) -> str:
+def _shorten_path_in_msg(msg: Any) -> Any:
     """
-    If message ends with a path (after ': '), shorten that path preserving internal spaces.
-    Fallback: return original msg unchanged.
+    Backward-compatible behavior:
+    - If message ends with a path after ': ', shorten that trailing path.
+    - Otherwise return msg unchanged.
     """
     if not isinstance(msg, str):
         return msg
 
-    # If message contains a colon-space then the trailing part is likely a path in many logs:
-    head, sep, tail = msg.rpartition(': ')
-    if sep and (('\\' in tail) or ('/' in tail)):
+    head, sep, tail = msg.rpartition(": ")
+    if sep and (("\\" in tail) or ("/" in tail)):
         shortened = short_path(tail)
         return f"{head}{sep}{shortened}"
 
-    # Otherwise leave unchanged
     return msg
 
 
 # ============================================================================
-# CONFIG
+# CONFIG (kept names; logic improved)
 # ============================================================================
-ENABLE_COLORS = True          # Colors in console
+ENABLE_COLORS = True          # Console colors (effective only if terminal supports)
 ENABLE_FILE_LOG = False       # Save logs to file
 LOG_FILE = "logs/generator.log"
 
@@ -52,111 +71,236 @@ COLORS = {
     "RESET": "\033[0m",
 }
 
-# Track entire pipeline start
 PIPELINE_START_TIME = time.time()
 
-# ============================================================================
-# HELPERS
-# ============================================================================
 
-def fmt_sec(sec):
+# ============================================================================
+# INTERNAL STATE
+# ============================================================================
+_PRINT_LOCK = threading.Lock()
+
+_LOG_DIR_READY = False
+_LOG_FD: Optional[int] = None
+_LOG_FILE_PATH: Optional[Path] = None
+
+
+def _is_tty() -> bool:
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def _color_allowed() -> bool:
+    """
+    Colors are used if:
+      - ENABLE_COLORS is True
+      - and stdout is a TTY
+      - and NO_COLOR isn't set
+    """
+    if not ENABLE_COLORS:
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return _is_tty()
+
+
+def configure_logging(
+    *,
+    enable_colors: Optional[bool] = None,
+    enable_file_log: Optional[bool] = None,
+    log_file: Optional[str] = None,
+) -> None:
+    """
+    Optional runtime configuration without touching import sites.
+    """
+    global ENABLE_COLORS, ENABLE_FILE_LOG, LOG_FILE, _LOG_FILE_PATH, _LOG_DIR_READY, _LOG_FD
+
+    if enable_colors is not None:
+        ENABLE_COLORS = bool(enable_colors)
+
+    if enable_file_log is not None:
+        ENABLE_FILE_LOG = bool(enable_file_log)
+
+    if log_file is not None:
+        LOG_FILE = str(log_file)
+        _LOG_FILE_PATH = None
+        _LOG_DIR_READY = False
+        if _LOG_FD is not None:
+            try:
+                os.close(_LOG_FD)
+            except Exception:
+                pass
+            _LOG_FD = None
+
+
+def fmt_sec(sec: float) -> str:
     """Return a clean human-readable time string."""
     if sec < 1:
-        return f"{sec*1000:.0f}ms"
+        return f"{sec * 1000:.0f}ms"
     if sec < 60:
         return f"{sec:.1f}s"
     return str(timedelta(seconds=int(sec)))
 
 
-def human_duration(seconds):
-    """Backward-compatible for old code."""
+def human_duration(seconds: float) -> str:
+    """Backward-compatible alias."""
     return fmt_sec(seconds)
 
 
-def _line(level, msg):
-    """ Standard log line formatter. """
-    ts = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
+def pipeline_elapsed() -> str:
+    """Elapsed time since module import (pipeline start)."""
+    return fmt_sec(time.time() - PIPELINE_START_TIME)
 
-    if ENABLE_COLORS:
+
+def _format_level(level: str) -> str:
+    if _color_allowed():
         color = COLORS.get(level, "")
         reset = COLORS["RESET"]
-        level_str = f"{color}{level:<5}{reset}"
-    else:
-        level_str = f"{level:<5}"
-
-    return f"{ts} | {level_str} | {msg}"
+        return f"{color}{level:<5}{reset}"
+    return f"{level:<5}"
 
 
-def _flush(line):
-    """Prints to stdout safely for multiprocessing."""
-    print(line, flush=True)
+def _line(level: str, msg: Any) -> str:
+    ts = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
+    return f"{ts} | {_format_level(level)} | {msg}"
 
-    if ENABLE_FILE_LOG:
-        os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
-        with open(LOG_FILE, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
+
+def _ensure_log_file_open() -> None:
+    """
+    Lazily open a process-local FD in append mode.
+    Keeps overhead low vs open/close on every log line.
+    """
+    global _LOG_DIR_READY, _LOG_FD, _LOG_FILE_PATH
+
+    if not ENABLE_FILE_LOG:
+        return
+
+    if _LOG_FILE_PATH is None:
+        _LOG_FILE_PATH = Path(LOG_FILE)
+
+    if not _LOG_DIR_READY:
+        # Avoid repeated mkdir calls
+        parent = _LOG_FILE_PATH.parent
+        if str(parent) and str(parent) != ".":
+            parent.mkdir(parents=True, exist_ok=True)
+        _LOG_DIR_READY = True
+
+    if _LOG_FD is None:
+        # O_APPEND ensures each write is appended (best-effort atomicity per process)
+        _LOG_FD = os.open(str(_LOG_FILE_PATH), os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o644)
+
+
+@atexit.register
+def _close_log_fd() -> None:
+    global _LOG_FD
+    if _LOG_FD is not None:
+        try:
+            os.close(_LOG_FD)
+        except Exception:
+            pass
+        _LOG_FD = None
+
+
+def _write_to_file(line: str) -> None:
+    if not ENABLE_FILE_LOG:
+        return
+    _ensure_log_file_open()
+    if _LOG_FD is None:
+        return
+    try:
+        os.write(_LOG_FD, (line + "\n").encode("utf-8", errors="replace"))
+    except Exception:
+        # File logging should never crash the pipeline
+        pass
+
+
+def _flush(line: str) -> None:
+    """
+    Prints to stdout safely for multiprocessing (flush) and reduces interleaving
+    within the same process via a lock. Multiprocess interleaving is still possible
+    (expected), but each call flushes promptly.
+    """
+    with _PRINT_LOCK:
+        print(line, flush=True)
+        _write_to_file(line)
 
 
 # ============================================================================
-# BASIC LOG LEVEL FUNCTIONS
+# BASIC LOG LEVEL FUNCTIONS (same names)
 # ============================================================================
-def info(msg):
+def info(msg: Any) -> None:
     msg = _shorten_path_in_msg(msg)
     _flush(_line("INFO", msg))
 
 
-def warn(msg):
+def warn(msg: Any) -> None:
     _flush(_line("WARN", msg))
 
 
-def fail(msg):
+def fail(msg: Any) -> None:
     _flush(_line("FAIL", msg))
 
 
-def skip(msg):
+def skip(msg: Any) -> None:
     _flush(_line("SKIP", msg))
 
 
-def done(msg):
+def done(msg: Any) -> None:
     _flush(_line("DONE", msg))
 
 
 # ============================================================================
-# STAGE CONTEXT MANAGER (Auto-timed)
+# STAGE CONTEXT MANAGER (Auto-timed) – improved exception logging
 # ============================================================================
+@dataclass
 class stage:
-    """Clean stage logging without arrows or tick marks."""
+    """
+    Usage:
+        with stage("Generating Dates"):
+            ...
 
-    def __init__(self, msg):
-        self.msg = msg
-        self.start = None
+    Behavior:
+      - Logs INFO at enter
+      - Logs DONE on successful exit with timing
+      - Logs FAIL on exception with timing, then re-raises
+    """
+    msg: str
+    start: Optional[float] = None
 
-    def __enter__(self):
+    def __enter__(self) -> "stage":
         self.start = time.time()
-        info(self.msg)   # No arrow
+        info(self.msg)
         return self
 
-    def __exit__(self, exc_type, exc, tb):
-        elapsed = fmt_sec(time.time() - self.start)
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        elapsed = fmt_sec(time.time() - (self.start or time.time()))
+        if exc_type is not None:
+            # Include exception type + message, but keep it compact
+            fail(f"{self.msg} failed in {elapsed}: {exc_type.__name__}: {exc}")
+            return False  # re-raise
         done(f"{self.msg} completed in {elapsed}")
+        return False
 
 
 # ============================================================================
-# ENHANCED WORK LOGGER (For Multiprocessing Workers)
+# ENHANCED WORK LOGGER (For Multiprocessing Workers) – same signature
 # ============================================================================
-def work(msg="", *, outfile=None, **_ignore):
+def work(msg: str = "", *, outfile: Any = None, **_ignore: Any) -> None:
     """
     WORK logger (multiprocessing-safe).
 
-    - Message is always authoritative
-    - No hidden state
-    - No ambiguous 'chunk' semantics
+    - Message is authoritative
+    - If msg is empty and outfile is provided, log outfile name
+    - Keeps previous visible format (including arrow) for compatibility
     """
-
     if msg:
         final = msg
     elif outfile:
-        final = f"→ {Path(outfile).name}"
+        try:
+            final = f"→ {Path(outfile).name}"
+        except Exception:
+            final = f"→ {outfile}"
     else:
         final = ""
 

--- a/src/utils/output_utils.py
+++ b/src/utils/output_utils.py
@@ -1,57 +1,177 @@
-import shutil
-from pathlib import Path
-import pyarrow.parquet as pq
-from datetime import datetime
+from __future__ import annotations
+
 import csv
-from typing import Optional, Union
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Union
 
 from src.utils.logging_utils import stage, done, info
 
+# ============================================================
+# Constants / shared
+# ============================================================
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_IGNORE_PATTERNS = shutil.ignore_patterns("_tmp_parts*", "tmp*", "*_tmp*")
+
 
 # ============================================================
-# Helpers
+# Parquet helpers (Power Query Date typing)
 # ============================================================
-def copy_sql_constraints(sql_root: Path):
-    project_root = Path(__file__).resolve().parents[2]
-    constraints_file = project_root / "scripts" / "sql" / "bootstrap" / "create_constraints.sql"
 
-    if not constraints_file.exists():
-        info("No create_constraints.sql found; skipping SQL constraints copy")
+def _datetime_cols(df) -> list[str]:
+    import pandas as pd
+    return [c for c in df.columns if pd.api.types.is_datetime64_any_dtype(df[c])]
+
+
+def _guess_date_cols(df) -> list[str]:
+    """
+    Heuristic: treat columns as "date columns" if:
+      - dtype is datetime64
+      - and name matches common date-like patterns
+    This avoids accidentally truncating true timestamps.
+    """
+    import pandas as pd
+
+    dt_cols = _datetime_cols(df)
+    if not dt_cols:
+        return []
+
+    picks: list[str] = []
+    for c in dt_cols:
+        cl = c.lower()
+        # common patterns in your project: Date, StartDate, EndDate, OpeningDate, ClosingDate, DOB, etc.
+        if cl == "date" or cl.endswith("date") or "date" in cl or cl in {"dob", "birthdate"}:
+            picks.append(c)
+    return picks
+
+
+def write_parquet_with_date32(
+    df,
+    out_path: Union[str, Path],
+    *,
+    date_cols: Optional[Sequence[str]] = None,
+    cast_all_datetime: bool = False,
+    compression: str = "snappy",
+    compression_level: Optional[int] = None,
+    force_date32: bool = True,
+) -> None:
+    """
+    Write Parquet with selected datetime columns stored as Arrow date32 so Power Query imports them as Date.
+
+    Selection:
+      - If date_cols is provided: cast only those columns (if they are datetime dtype)
+      - Else if cast_all_datetime=True: cast all datetime64 columns
+      - Else: cast "date-like" datetime columns based on name heuristic
+
+    Notes:
+      - Casting timestamp -> date truncates time-of-day. We normalize selected cols to midnight before casting.
+      - If pyarrow isn't available:
+          - if force_date32=True: fallback converts selected cols to python date objects (object dtype) just for writing
+          - else: plain df.to_parquet
+    """
+    import pandas as pd
+
+    out_path = Path(out_path)
+
+    dt_cols = _datetime_cols(df)
+    if not dt_cols:
+        df.to_parquet(out_path, index=False)
         return
 
-    schema_dir = sql_root / "schema"
-    schema_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(constraints_file, schema_dir / "03_create_constraints.sql")
-    info("Included create_constraints.sql in final output")
+    if date_cols is not None:
+        target = [c for c in date_cols if c in df.columns and c in dt_cols]
+    elif cast_all_datetime:
+        target = list(dt_cols)
+    else:
+        target = _guess_date_cols(df)
 
-
-def copy_sql_views(sql_root: Path):
-    project_root = Path(__file__).resolve().parents[2]
-    views_file = project_root / "scripts" / "sql" / "views" / "create_views.sql"
-
-    if not views_file.exists():
-        info("No create_views.sql found; skipping SQL views copy")
+    # Nothing selected -> default parquet write
+    if not target:
+        df.to_parquet(out_path, index=False)
         return
 
-    schema_dir = sql_root / "schema"
-    schema_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(views_file, schema_dir / "04_create_views.sql")
-    info("Included create_views.sql in final output")
+    # Normalize selected cols (drop any time component deterministically)
+    df2 = df.copy()
+    for c in target:
+        df2[c] = pd.to_datetime(df2[c]).dt.normalize()
 
-
-def copy_sql_indexes(sql_root: Path):
-    project_root = Path(__file__).resolve().parents[2]
-    cci_file = project_root / "scripts" / "sql" / "columnstore" / "create_drop_cci.sql"
-
-    if not cci_file.exists():
-        info("No create_drop_cci.sql found; skipping SQL indexes")
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except Exception:
+        if force_date32:
+            # Fallback: python date objects for selected cols
+            for c in target:
+                df2[c] = pd.to_datetime(df2[c]).dt.date
+            df2.to_parquet(out_path, index=False)
+        else:
+            df2.to_parquet(out_path, index=False)
         return
 
-    indexes_dir = sql_root / "indexes"
-    indexes_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(cci_file, indexes_dir / "create_drop_cci.sql")
-    info("Included create_drop_cci.sql in SQL indexes")
+    table = pa.Table.from_pandas(df2, preserve_index=False)
 
+    target_set = set(target)
+    fields = []
+    for f in table.schema:
+        if f.name in target_set:
+            fields.append(pa.field(f.name, pa.date32()))
+        else:
+            fields.append(f)
+
+    table = table.cast(pa.schema(fields), safe=False)
+
+    kwargs = {"compression": str(compression)}
+    if compression_level is not None:
+        kwargs["compression_level"] = int(compression_level)
+
+    pq.write_table(table, str(out_path), **kwargs)
+
+
+# ============================================================
+# SQL helper file copies
+# ============================================================
+
+def _copy_if_exists(src: Path, dst: Path, log_msg: str) -> None:
+    if not src.exists():
+        info(f"{src.name} not found; skipping")
+        return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    info(log_msg)
+
+
+def copy_sql_constraints(sql_root: Path) -> None:
+    constraints_file = _PROJECT_ROOT / "scripts" / "sql" / "bootstrap" / "create_constraints.sql"
+    _copy_if_exists(
+        constraints_file,
+        sql_root / "schema" / "03_create_constraints.sql",
+        "Included create_constraints.sql in final output",
+    )
+
+
+def copy_sql_views(sql_root: Path) -> None:
+    views_file = _PROJECT_ROOT / "scripts" / "sql" / "views" / "create_views.sql"
+    _copy_if_exists(
+        views_file,
+        sql_root / "schema" / "04_create_views.sql",
+        "Included create_views.sql in final output",
+    )
+
+
+def copy_sql_indexes(sql_root: Path) -> None:
+    cci_file = _PROJECT_ROOT / "scripts" / "sql" / "columnstore" / "create_drop_cci.sql"
+    _copy_if_exists(
+        cci_file,
+        sql_root / "indexes" / "create_drop_cci.sql",
+        "Included create_drop_cci.sql in SQL indexes",
+    )
+
+
+# ============================================================
+# Misc helpers
+# ============================================================
 
 def format_number_short(n: int) -> str:
     if n >= 1_000_000_000:
@@ -90,6 +210,16 @@ def _copy_config_files_into_run_folder(
     _copy(model_yaml_path, "model.yaml")
 
 
+def _ensure_clean_dir(p: Path) -> None:
+    if p.exists():
+        shutil.rmtree(p, ignore_errors=True)
+    p.mkdir(parents=True, exist_ok=True)
+
+
+# ============================================================
+# Final output packager
+# ============================================================
+
 def create_final_output_folder(
     final_folder_root: Path,
     parquet_dims: Path,
@@ -104,22 +234,29 @@ def create_final_output_folder(
     """
     Packs cleaned dimension + fact data according to config rules.
     Also copies config/model YAML files into <final_folder>/config/ for traceability.
+
+    Date logic:
+      - When file_format == "parquet", dimensions are rewritten so date-like datetime
+        columns are stored as Arrow date32 (Power Query imports as Date).
+      - Facts are NOT rewritten (too large); they are copied as produced.
     """
     stage("Creating Final Output Folder")
+
     now = datetime.now()
-    timestamp = now.strftime("%Y-%m-%d %I_%M_%S %p")  # windows-safe
+    timestamp = now.strftime("%Y-%m-%d %I_%M_%S %p")  # windows-safe (kept)
 
     customer_total = cfg["customers"]["total_customers"]
     sales_total = sales_cfg["total_rows"]
 
-    cust_short = format_number_short(customer_total)
-    sales_short = format_number_short(sales_total)
+    cust_short = format_number_short(int(customer_total))
+    sales_short = format_number_short(int(sales_total))
 
+    ff = file_format.lower()
     fmt_label = {
         "deltaparquet": "DeltaParquet",
         "parquet": "Parquet",
         "csv": "CSV",
-    }.get(file_format.lower(), file_format)
+    }.get(ff, file_format)
 
     dataset_name = f"{timestamp} Customers {cust_short} Sales {sales_short} {fmt_label}"
 
@@ -127,44 +264,62 @@ def create_final_output_folder(
     dims_out = final_folder / "dimensions"
     facts_out = final_folder / "facts"
 
-    if final_folder.exists():
-        shutil.rmtree(final_folder, ignore_errors=True)
-
-    final_folder.mkdir(parents=True, exist_ok=True)
+    _ensure_clean_dir(final_folder)
     dims_out.mkdir(parents=True, exist_ok=True)
     facts_out.mkdir(parents=True, exist_ok=True)
 
-    # NEW: copy yaml specs into <final_folder>/config/
     _copy_config_files_into_run_folder(
         final_folder=final_folder,
         config_yaml_path=config_yaml_path,
         model_yaml_path=model_yaml_path,
     )
 
-    ff = file_format.lower()
+    # Optional packaging controls (safe defaults)
+    packaging_cfg = cfg.get("packaging", {}) if isinstance(cfg, dict) else {}
+    dim_parquet_compression = packaging_cfg.get("dim_parquet_compression", "snappy")
+    dim_parquet_compression_level = packaging_cfg.get("dim_parquet_compression_level", None)
+    dim_force_date32 = bool(packaging_cfg.get("dim_force_date32", True))
 
     # --------------------------------------------------------
     # DIMENSIONS
     # --------------------------------------------------------
     if ff == "parquet":
+        # Rewrite dims to enforce Arrow date32 for date-like columns (Power Query friendly)
+        import pandas as pd
+
         for f in parquet_dims.glob("*.parquet"):
-            shutil.copy2(f, dims_out / f.name)
+            df = pd.read_parquet(f)
+            out_f = dims_out / f.name
+            write_parquet_with_date32(
+                df,
+                out_f,
+                # conservative default: only date-like columns
+                cast_all_datetime=False,
+                compression=dim_parquet_compression,
+                compression_level=dim_parquet_compression_level,
+                force_date32=dim_force_date32,
+            )
 
     elif ff == "csv":
         import pandas as pd
 
         for f in parquet_dims.glob("*.parquet"):
             df = pd.read_parquet(f)
-            (dims_out / f"{f.stem}.csv").parent.mkdir(parents=True, exist_ok=True)
+            out_csv = dims_out / f"{f.stem}.csv"
+            out_csv.parent.mkdir(parents=True, exist_ok=True)
             df.to_csv(
-                dims_out / f"{f.stem}.csv",
+                out_csv,
                 index=False,
                 encoding="utf-8",
                 quoting=csv.QUOTE_MINIMAL,
             )
 
     elif ff == "deltaparquet":
+        # Keep behavior, but we can still enforce date32 by casting date-like timestamp fields in Arrow table.
         from deltalake import write_deltalake
+
+        import pyarrow as pa
+        import pyarrow.parquet as pq
 
         for f in parquet_dims.glob("*.parquet"):
             dim_name = f.stem
@@ -172,6 +327,25 @@ def create_final_output_folder(
             delta_out.mkdir(parents=True, exist_ok=True)
 
             table = pq.read_table(f)
+
+            # Cast date-like timestamp columns to date32 for better Power BI behavior
+            schema = table.schema
+            fields = []
+            for field in schema:
+                name = field.name
+                nl = name.lower()
+                # only cast if it's timestamp AND name looks date-like
+                if pa.types.is_timestamp(field.type) and (nl == "date" or nl.endswith("date") or "date" in nl or nl in {"dob", "birthdate"}):
+                    fields.append(pa.field(name, pa.date32()))
+                else:
+                    fields.append(field)
+
+            try:
+                table = table.cast(pa.schema(fields), safe=False)
+            except Exception:
+                # If cast fails, just keep original (non-fatal)
+                pass
+
             write_deltalake(str(delta_out), table, mode="overwrite")
 
     else:
@@ -181,13 +355,12 @@ def create_final_output_folder(
     # FACTS (sales)
     # --------------------------------------------------------
     sales_target = facts_out / "sales"
-
     if sales_target.exists():
         shutil.rmtree(sales_target, ignore_errors=True)
 
     # DeltaParquet
     if ff == "deltaparquet":
-        delta_src = None
+        delta_src: Optional[Path] = None
 
         cfg_delta = sales_cfg.get("delta_output_folder")
         if cfg_delta:
@@ -206,7 +379,7 @@ def create_final_output_folder(
         shutil.copytree(
             delta_src,
             sales_target,
-            ignore=shutil.ignore_patterns("_tmp_parts*", "tmp*", "*_tmp*"),
+            ignore=_IGNORE_PATTERNS,
         )
 
         done("Creating Final Output Folder")
@@ -219,8 +392,10 @@ def create_final_output_folder(
             shutil.copytree(
                 partitioned_sales,
                 sales_target,
-                ignore=shutil.ignore_patterns("_tmp_parts*", "tmp*", "*_tmp*"),
+                ignore=_IGNORE_PATTERNS,
             )
+        else:
+            info("No sales parquet folder found to copy; facts/sales will be empty.")
 
         done("Creating Final Output Folder")
         return final_folder
@@ -234,18 +409,21 @@ def create_final_output_folder(
         sql_root = final_folder / "sql"
         sql_root.mkdir(parents=True, exist_ok=True)
 
-        for file in partitioned_sales.rglob("*.parquet"):
-            rel = file.relative_to(partitioned_sales)
-            out_file = sales_target / rel.with_suffix(".csv")
-            out_file.parent.mkdir(parents=True, exist_ok=True)
+        if partitioned_sales.exists():
+            for file in partitioned_sales.rglob("*.parquet"):
+                rel = file.relative_to(partitioned_sales)
+                out_file = sales_target / rel.with_suffix(".csv")
+                out_file.parent.mkdir(parents=True, exist_ok=True)
 
-            df = pd.read_parquet(file)
-            df.to_csv(
-                out_file,
-                index=False,
-                encoding="utf-8",
-                quoting=csv.QUOTE_MINIMAL,
-            )
+                df = pd.read_parquet(file)
+                df.to_csv(
+                    out_file,
+                    index=False,
+                    encoding="utf-8",
+                    quoting=csv.QUOTE_MINIMAL,
+                )
+        else:
+            info("No sales parquet folder found to convert; facts/sales will be empty.")
 
         copy_sql_indexes(sql_root)
         copy_sql_constraints(sql_root)


### PR DESCRIPTION
- Added a shared Parquet writer to store date-like columns as Arrow date32, so Power Query imports them as Date (no slow DateTime transforms).
- Applied date32 writing in dimension outputs and during final packaging of dimensions.
- Fixed Stores generation failures (handles seed: null, correct normalization for DatetimeIndex) and ensured Opening/Closing dates are date32.
- Made Dates “current” flags deterministic (IsToday / IsCurrent*) via a stable as_of_date anchor.
- Included small refactors/optimizations across Geography, Promotions, Currency, Static Loader, and Logging.

Closes #35 