### PR TITLE
fix(delta): robust write_deltalake import and preserve root error

### DIFF
--- a/src/facts/sales/sales_writer.py
+++ b/src/facts/sales/sales_writer.py
@@ -281,9 +281,17 @@ def write_delta_partitioned(
     os.makedirs(delta_output_folder, exist_ok=True)
 
     try:
-        from deltalake import write_deltalake
-    except Exception as e:
-        raise RuntimeError("deltalake is required for Delta output") from e
+        # Preferred in many delta-rs versions
+        from deltalake import write_deltalake  # type: ignore
+    except Exception as e1:
+        try:
+            # Fallback for versions where top-level export differs
+            from deltalake.writer import write_deltalake  # type: ignore
+        except Exception as e2:
+            raise RuntimeError(
+                "deltalake is required for Delta output, but import failed. "
+                f"top-level error={e1!r}; fallback error={e2!r}"
+            ) from e2
 
     info(f"[DELTA] Writing {len(part_files)} parts (Arrow -> Delta)")
 


### PR DESCRIPTION
Delta output was failing with deltalake is required for Delta output even when deltalake was installed. The import in src/facts/sales/sales_writer.py was catching broad exceptions and masking the underlying error.

Changes:
- Add version-tolerant import fallback for write_deltalake (deltalake → deltalake.writer)
- Improve failure message to include the original exception(s) for faster debugging

Closes #41