### PR TITLE
chore(github): simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,8 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to report a bug with clear reproduction steps.
-        If this is a security issue, do **not** file it here—use the Security Policy instead.
+        Minimal bug report. If this is security-related, use SECURITY.md instead.
 
   - type: textarea
     id: summary
@@ -22,113 +21,34 @@ body:
     id: repro
     attributes:
       label: Steps to reproduce
-      description: Exact steps (include commands, UI selections, and inputs).
+      description: Exact steps (include commands/UI selections).
       placeholder: |
         1) Run ...
-        2) Set config ...
+        2) Set ...
         3) Click ...
         4) Observe ...
     validations:
       required: true
 
   - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-      placeholder: "What did you expect to happen?"
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-      placeholder: "What actually happened?"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: surface
-    attributes:
-      label: Affected surface
-      description: Where are you seeing this?
-      options:
-        - CLI (src/cli.py)
-        - Streamlit UI (main.py / .streamlit)
-        - Generator core (src/engine / src/facts)
-        - SQL Server import (scripts/run_sql_server_import.ps1 / src/tools/sql)
-        - Packaging / Power BI (src/engine/powerbi_packaging.py)
-        - Other / Not sure
-    validations:
-      required: true
-
-  - type: textarea
-    id: command
-    attributes:
-      label: Command / invocation used
-      description: If you used CLI or scripts, paste the exact command.
-      placeholder: |
-        Example:
-        .\scripts\run_generator.ps1 -Config .\config.yaml -Models .\models.yaml
-    validations:
-      required: false
-
-  - type: textarea
-    id: config_snippet
-    attributes:
-      label: Relevant config/models snippet
-      description: Paste only the relevant parts (remove secrets). Include `sales_output`, file_format, seeds, etc.
-      render: yaml
-      placeholder: |
-        sales:
-          file_format: "parquet"
-          sales_output: "sales_order"
-    validations:
-      required: false
-
-  - type: input
-    id: version
-    attributes:
-      label: Version / commit
-      description: Tag or commit SHA (or “local/unreleased”).
-      placeholder: "Example: v0.6.0 or 1a2b3c4"
-    validations:
-      required: false
-
-  - type: dropdown
-    id: os
-    attributes:
-      label: OS
-      options:
-        - Windows
-        - macOS
-        - Linux
-        - Other
-    validations:
-      required: true
-
-  - type: input
-    id: python
-    attributes:
-      label: Python version
-      placeholder: "Example: 3.11.7"
-    validations:
-      required: false
-
-  - type: textarea
     id: logs
     attributes:
       label: Logs / stack trace
-      description: Paste error output (PowerShell, Python tracebacks, Streamlit logs).
+      description: Paste the error output (PowerShell, Python traceback, Streamlit logs).
       render: text
       placeholder: "Paste logs here..."
     validations:
       required: false
 
   - type: textarea
-    id: extra
+    id: config_snippet
     attributes:
-      label: Extra context
-      description: Any other details (dataset size, machine limits, expected performance, etc.).
+      label: Relevant config/models snippet (optional)
+      description: Paste only relevant parts (no secrets).
+      render: yaml
+      placeholder: |
+        sales:
+          file_format: "parquet"
+          skip_order_cols: true
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,100 +1,46 @@
 name: Feature request
-description: Propose a change or new capability (generator, UI, SQL import, packaging).
+description: Propose a change or new capability.
 title: "feat: "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to propose a feature. Keep it scoped and testable.
+        Minimal feature request. Keep it testable and backward-compatible.
 
   - type: textarea
-    id: problem
+    id: request
     attributes:
-      label: Problem statement
-      description: What problem are you trying to solve? Who benefits?
-      placeholder: "Example: Need an option to generate SalesOrderHeader and SalesOrderDetail separately for SQL Server demos."
-    validations:
-      required: true
-
-  - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed solution
-      description: Describe the approach and expected behavior.
-      placeholder: "Example: Add config key sales_output: sales|sales_order|both, update packaging and SQL import scripts accordingly."
-    validations:
-      required: true
-
-  - type: dropdown
-    id: area
-    attributes:
-      label: Area
-      options:
-        - Generator core (src/engine / src/facts)
-        - Dimensions (src/dimensions)
-        - Streamlit UI (main.py / .streamlit)
-        - Scripts (scripts/*.ps1)
-        - SQL tooling/import (scripts/sql / src/tools/sql)
-        - Packaging / Power BI
-        - Other
-    validations:
-      required: true
-
-  - type: textarea
-    id: config_impact
-    attributes:
-      label: Config / compatibility impact
-      description: What new keys/behavior? Any breaking changes? (Prefer config-first + backward-compatible.)
+      label: What do you want and why?
+      description: Problem + proposed solution (include expected behavior).
       placeholder: |
-        - New key: sales.sales_output
-        - Default: sales (no change)
-        - Backward compatible: yes
+        Problem:
+        - ...
+
+        Proposal:
+        - ...
     validations:
       required: true
 
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
-      description: Concrete checklist of what “done” means.
+      label: Acceptance criteria (optional)
+      description: A short checklist of what “done” means.
       placeholder: |
-        - [ ] CLI supports the new option
-        - [ ] UI exposes the option safely
-        - [ ] Output files match schema
-        - [ ] SQL import handles new tables/views
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: What else could we do? Why is this better?
+        - [ ] ...
+        - [ ] ...
     validations:
       required: false
 
-  - type: dropdown
-    id: priority
+  - type: textarea
+    id: notes
     attributes:
-      label: Priority
-      options:
-        - P0 (blocker)
-        - P1 (important)
-        - P2 (nice-to-have)
+      label: Notes / compatibility impact (optional)
+      description: Mention config keys, breaking changes, perf impact, etc.
+      placeholder: |
+        - New key(s): ...
+        - Default behavior unchanged: yes/no
+        - Risk: ...
     validations:
-      required: true
-
-  - type: checkboxes
-    id: risks
-    attributes:
-      label: Risk / rollout notes
-      options:
-        - label: This change might be breaking (schema/config behavior)
-          required: false
-        - label: This change affects performance or memory usage
-          required: false
-        - label: This change affects SQL Server import scripts
-          required: false
-        - label: This change affects Power BI packaging
-          required: false
+      required: false


### PR DESCRIPTION
- Simplify .github/ISSUE_TEMPLATE/bug_report.yml and feature_request.yml to reduce form complexity for a solo-maintained repo.
- Keep only the essential fields (summary/repro/logs for bugs; request/criteria for features).
- No code or runtime behavior changes.