### PR TITLE
Fix duplicate SalesOrderNumber; add configurable max lines per order

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,11 +31,12 @@ sales:
   parquet_folder: "./data/parquet_dims"
   out_folder: "./data/fact_out"
 
-  total_rows: 20415971
+  total_rows: 250041597
   chunk_size: 2000000
-
+  max_lines_per_order: 6
+  
   file_format: "parquet"          # csv | parquet | deltaparquet
-  sales_output: "both"           # sales | sales_order | both
+  sales_output: "sales"           # sales | sales_order | both
   write_delta: true
   delta_output_folder: "./data/fact_out/delta"
 

--- a/src/facts/sales/sales_logic/globals.py
+++ b/src/facts/sales/sales_logic/globals.py
@@ -142,6 +142,19 @@ class State:
     chunk_size = None
     row_group_size = None
     compression = None
+    
+    # CRITICAL: constant per-run stride for chunk order-id ranges
+    # (task.py validates this; chunk_builder uses it to avoid overlaps)
+    chunk_size = None
+
+    # Forward-compat aliases for SalesOrderNumber generation
+    order_id_stride_orders = None      # usually == chunk_size
+    order_id_run_id = None             # 0..999 (used in SalesOrderNumber prefix)
+
+    # used by task.py when deciding to drop order cols in Sales output
+    skip_order_cols_requested = None
+    
+    max_lines_per_order = 6
 
     # parquet tuning
     parquet_dict_exclude = None

--- a/src/facts/sales/worker/init.py
+++ b/src/facts/sales/worker/init.py
@@ -5,20 +5,25 @@ from typing import Any, List, Optional
 
 import numpy as np
 
+from ..output_paths import (
+    OutputPaths,
+    TABLE_SALES,
+    TABLE_SALES_ORDER_DETAIL,
+    TABLE_SALES_ORDER_HEADER,
+)
 from ..sales_logic import bind_globals
-from ..output_paths import OutputPaths, TABLE_SALES, TABLE_SALES_ORDER_DETAIL, TABLE_SALES_ORDER_HEADER
+from .schemas import build_worker_schemas
 
 try:
     from ..output_paths import TABLE_SALES_RETURN  # type: ignore
 except Exception:
     TABLE_SALES_RETURN = None  # type: ignore
 
-from .schemas import build_worker_schemas
-
 
 # ---------------------------------------------------------------------
 # Small helpers (kept close to monolith behavior for compatibility)
 # ---------------------------------------------------------------------
+
 
 def build_buckets_from_key(key: Any) -> list[np.ndarray]:
     key_np = np.asarray(key, dtype=np.int64)
@@ -133,6 +138,7 @@ def _infer_T_from_date_pool(date_pool: Any) -> int:
 # Canonical: day-accurate effective-dated bridge index
 # ---------------------------------------------------------------------
 
+
 def _build_salesperson_effective_by_store(
     *,
     store_keys: np.ndarray,
@@ -174,7 +180,6 @@ def _build_salesperson_effective_by_store(
     if start_raw.shape[0] != assign_store.shape[0] or end_raw.shape[0] != assign_store.shape[0]:
         raise RuntimeError("employee assignment arrays must align (dates vs keys)")
 
-    # Normalize missing dates
     FAR_FUTURE = np.datetime64("2262-04-11", "D")
     FAR_PAST = np.datetime64("1900-01-01", "D")
 
@@ -189,7 +194,6 @@ def _build_salesperson_effective_by_store(
     if nat_e.any():
         end_fixed[nat_e] = FAR_FUTURE
 
-    # Optional: filter to plausible store range
     valid_store = (assign_store >= 0) & (assign_store <= max_store_key)
     if not valid_store.all():
         assign_store = assign_store[valid_store]
@@ -203,7 +207,6 @@ def _build_salesperson_effective_by_store(
         if assign_is_primary is not None:
             assign_is_primary = np.asarray(assign_is_primary, dtype=bool)[valid_store]
 
-    # Filter invalid windows (start > end)
     ok_window = start_fixed <= end_fixed
     if not ok_window.all():
         assign_store = assign_store[ok_window]
@@ -233,7 +236,6 @@ def _build_salesperson_effective_by_store(
 
     weights = fte * np.where(is_primary, float(primary_boost), 1.0)
 
-    # Group by store
     order = np.argsort(assign_store, kind="mergesort")
     s_sorted = assign_store[order]
     starts = np.flatnonzero(np.r_[True, s_sorted[1:] != s_sorted[:-1]])
@@ -272,10 +274,6 @@ def _build_salesperson_by_store_month(
     primary_boost: float = 2.0,
     seed: int = 12345,
 ) -> Optional[np.ndarray]:
-    """
-    Legacy behavior: chooses ONE employee per (StoreKey, Month).
-    Cannot enforce EndDate within a month (rounds to month buckets).
-    """
     if assign_store is None or assign_emp is None or assign_start is None or assign_end is None:
         return None
 
@@ -291,11 +289,8 @@ def _build_salesperson_by_store_month(
     if assign_start.shape[0] != assign_store.shape[0] or assign_end.shape[0] != assign_store.shape[0]:
         raise RuntimeError("employee assignment arrays must align (dates vs keys)")
 
-    # --- FIX: normalize NaT dates ---
-    # NaT StartDate => far past (always eligible until EndDate)
-    # NaT EndDate   => far future (open-ended)
     FAR_PAST = np.datetime64("1900-01-01", "D")
-    FAR_FUTURE = np.datetime64("2262-04-11", "D")  # max safe day for numpy datetime64
+    FAR_FUTURE = np.datetime64("2262-04-11", "D")
 
     if np.isnat(assign_start).any():
         assign_start = assign_start.copy()
@@ -305,7 +300,6 @@ def _build_salesperson_by_store_month(
         assign_end = assign_end.copy()
         assign_end[np.isnat(assign_end)] = FAR_FUTURE
 
-    # Optional: drop invalid windows
     ok = assign_start <= assign_end
     if not np.all(ok):
         assign_store = assign_store[ok]
@@ -366,7 +360,7 @@ def _build_salesperson_by_store_month(
         if store < 0 or store > max_store_key:
             continue
 
-        idxs = order[int(s): int(e)]
+        idxs = order[int(s) : int(e)]
         if idxs.size == 0:
             continue
 
@@ -394,6 +388,7 @@ def _build_salesperson_by_store_month(
 # ---------------------------------------------------------------------
 # Brand popularity model helper (unchanged)
 # ---------------------------------------------------------------------
+
 
 def _build_brand_prob_by_month_rotate_winner(
     rng: np.random.Generator,
@@ -429,8 +424,8 @@ def _build_brand_prob_by_month_rotate_winner(
 # Main entrypoint
 # ---------------------------------------------------------------------
 
+
 def init_sales_worker(worker_cfg: dict) -> None:
-    # parse required config
     try:
         product_np = worker_cfg["product_np"]
         product_brand_key = worker_cfg.get("product_brand_key")
@@ -462,7 +457,7 @@ def init_sales_worker(worker_cfg: dict) -> None:
         employee_assign_is_primary = worker_cfg.get("employee_assign_is_primary")
         employee_primary_boost = float(worker_cfg.get("employee_primary_boost", 2.0))
         employee_seed = int(worker_cfg.get("employee_salesperson_seed", worker_cfg.get("seed_master", 12345)))
-        employee_assign_role = worker_cfg.get("employee_assign_role")  # array[str], same length as employee_assign_employee_key
+        employee_assign_role = worker_cfg.get("employee_assign_role")
         salesperson_roles = worker_cfg.get("salesperson_roles", ["Sales Associate"])
 
         op = worker_cfg["output_paths"]
@@ -471,6 +466,10 @@ def init_sales_worker(worker_cfg: dict) -> None:
 
         file_format = worker_cfg.get("file_format") or op.get("file_format")
         out_folder = worker_cfg.get("out_folder") or op.get("out_folder")
+        if not file_format:
+            raise RuntimeError("file_format is required (worker_cfg.file_format or output_paths.file_format)")
+        if not out_folder:
+            raise RuntimeError("out_folder is required (worker_cfg.out_folder or output_paths.out_folder)")
 
         row_group_size = int(worker_cfg.get("row_group_size", 2_000_000))
         compression = str(worker_cfg.get("compression", "snappy"))
@@ -478,7 +477,7 @@ def init_sales_worker(worker_cfg: dict) -> None:
         # ------------------------------------------------------------
         # CRITICAL: SalesOrderNumber uniqueness depends on a CONSTANT
         # per-run stride for chunk order-id ranges (NOT per-task batch size).
-        # Support alias 'order_id_stride_orders' for forward-compat.
+        # Prefer 'order_id_stride_orders'; fall back to 'chunk_size'.
         # ------------------------------------------------------------
         stride_raw = worker_cfg.get("order_id_stride_orders", None)
         if stride_raw is None:
@@ -492,10 +491,23 @@ def init_sales_worker(worker_cfg: dict) -> None:
                 "space across chunks and must be constant across the run."
             )
 
+        # ------------------------------------------------------------
+        # Per-run id for SalesOrderNumber (0..999).
+        # If caller doesn't provide it, derive deterministically from seed_master.
+        # ------------------------------------------------------------
+        run_id_raw = worker_cfg.get("order_id_run_id", None)
+        if run_id_raw is None:
+            seed_master = int(worker_cfg.get("seed_master", 0) or 0)
+            order_id_run_id = int(seed_master % 1000)
+        else:
+            order_id_run_id = int(run_id_raw)
+
+        if order_id_run_id < 0 or order_id_run_id > 999:
+            raise RuntimeError(f"order_id_run_id must be in [0,999], got {order_id_run_id}")
+
         no_discount_key = worker_cfg["no_discount_key"]
         delta_output_folder = worker_cfg.get("delta_output_folder") or op.get("delta_output_folder")
         merged_file = worker_cfg.get("merged_file") or op.get("merged_file")
-
         write_delta = worker_cfg.get("write_delta", False)
 
         skip_order_cols = worker_cfg["skip_order_cols"]
@@ -514,14 +526,18 @@ def init_sales_worker(worker_cfg: dict) -> None:
         if sales_output in {"sales_order", "both"}:
             skip_order_cols = False
 
-        partition_enabled = worker_cfg.get("partition_enabled", False)
+        partition_enabled = bool(worker_cfg.get("partition_enabled", False))
         partition_cols = worker_cfg.get("partition_cols") or []
         models_cfg = worker_cfg.get("models_cfg")
 
         parquet_dict_exclude = worker_cfg.get("parquet_dict_exclude")
         write_pyarrow = worker_cfg.get("write_pyarrow", True)
 
-        # optional legacy toggle
+        # NEW: configurable cap for SalesOrderLineNumber per SalesOrderNumber
+        max_lines_per_order = int_or(worker_cfg.get("max_lines_per_order"), 6)
+        if max_lines_per_order < 1:
+            raise RuntimeError(f"max_lines_per_order must be >= 1, got {max_lines_per_order}")
+
         legacy_salesperson_by_store_month = bool(worker_cfg.get("legacy_salesperson_by_store_month", False))
 
     except KeyError as e:
@@ -540,7 +556,6 @@ def init_sales_worker(worker_cfg: dict) -> None:
 
     # ------------------------------------------------------------
     # Filter employee assignment rows to sales-eligible roles
-    # (so Store Manager / Fulfillment etc never appear in SalesPersonEmployeeKey)
     # ------------------------------------------------------------
     if employee_assign_employee_key is not None and employee_assign_store_key is not None:
         emp_key = np.asarray(employee_assign_employee_key, dtype=np.int64)
@@ -553,7 +568,6 @@ def init_sales_worker(worker_cfg: dict) -> None:
             # fallback if role not provided: at least exclude Store Manager key range (30M..40M)
             mask = emp_key >= 40_000_000
 
-        # Apply mask consistently across all assignment arrays
         employee_assign_store_key = np.asarray(employee_assign_store_key, dtype=np.int64)[mask]
         employee_assign_employee_key = emp_key[mask]
         employee_assign_start_date = np.asarray(employee_assign_start_date, dtype="datetime64[D]")[mask]
@@ -568,7 +582,6 @@ def init_sales_worker(worker_cfg: dict) -> None:
     else:
         salesperson_global_pool = None
 
-    # Canonical (day-accurate)
     salesperson_effective_by_store = _build_salesperson_effective_by_store(
         store_keys=store_keys,
         assign_store=employee_assign_store_key,
@@ -580,7 +593,6 @@ def init_sales_worker(worker_cfg: dict) -> None:
         primary_boost=employee_primary_boost,
     )
 
-    # Optional legacy (month-rounded)
     salesperson_by_store_month = None
     if legacy_salesperson_by_store_month:
         salesperson_by_store_month = _build_salesperson_by_store_month(
@@ -692,7 +704,13 @@ def init_sales_worker(worker_cfg: dict) -> None:
             "date_prob": date_prob,
             "file_format": file_format,
             "out_folder": out_folder,
+
+            # CRITICAL: constant per-run stride used to partition SalesOrderNumber ranges
             "chunk_size": int(max(1, chunk_size)),
+            "order_id_stride_orders": int(max(1, chunk_size)),
+            "order_id_run_id": int(order_id_run_id),
+            "max_lines_per_order": int(max_lines_per_order),
+            
             "row_group_size": int(max(1, row_group_size)),
             "compression": compression,
             "output_paths": output_paths,

--- a/src/facts/sales/worker/task.py
+++ b/src/facts/sales/worker/task.py
@@ -340,36 +340,55 @@ def _profile_lut_from_dim() -> Optional[np.ndarray]:
 
 
 def _ensure_time_key_on_lines(table: pa.Table, *, seed: int) -> pa.Table:
-    """Add TimeKey to a line-level table; constant within SalesOrderNumber if present."""
-    if "TimeKey" in table.column_names:
-        return table
-
+    """Ensure TimeKey exists and is constant within SalesOrderNumber (if present)."""
     rng = np.random.default_rng(seed)
 
     profile_lut = _profile_lut_from_dim()
     has_channel = "SalesChannelKey" in table.column_names and profile_lut is not None
 
+    # Helper: compute first-row index per order (vectorized)
+    def _first_row_per_order(enc: pa.DictionaryArray, n_orders: int) -> np.ndarray:
+        inv = np.asarray(enc.indices.to_numpy(zero_copy_only=False), dtype=np.int64)
+        pos = np.arange(inv.size, dtype=np.int64)
+        first = np.full(n_orders, inv.size, dtype=np.int64)
+        np.minimum.at(first, inv, pos)
+        # safety: should never remain inv.size
+        first[first == inv.size] = 0
+        return first
+
     if "SalesOrderNumber" in table.column_names:
         order_col = table["SalesOrderNumber"]
         if isinstance(order_col, pa.ChunkedArray):
             order_col = order_col.combine_chunks()
+
         enc = pc.dictionary_encode(order_col)
         n_orders = len(enc.dictionary)
 
+        # If TimeKey already exists, FORCE it to be constant per order by taking first row per order.
+        if "TimeKey" in table.column_names:
+            tc = table["TimeKey"]
+            if isinstance(tc, pa.ChunkedArray):
+                tc = tc.combine_chunks()
+            tc_np = np.asarray(tc.to_numpy(zero_copy_only=False), dtype=np.int16)
+
+            first = _first_row_per_order(enc, n_orders)
+            per_order_time = tc_np[first].astype(np.int16, copy=False)
+
+            per_order_arr = pa.array(per_order_time, type=pa.int16())
+            time_col = pc.take(per_order_arr, enc.indices)
+
+            idx = table.schema.get_field_index("TimeKey")
+            return table.set_column(idx, "TimeKey", time_col)
+
+        # Else: generate per-order TimeKey (your existing behavior)
         if has_channel:
             sc_col = table["SalesChannelKey"]
             if isinstance(sc_col, pa.ChunkedArray):
                 sc_col = sc_col.combine_chunks()
             sc_np = np.asarray(sc_col.to_numpy(zero_copy_only=False), dtype=np.int16)
 
-            inv = np.asarray(enc.indices.to_numpy(zero_copy_only=False), dtype=np.int64)
-            first = np.full(n_orders, -1, dtype=np.int64)
-            for i in range(inv.shape[0]):
-                j = inv[i]
-                if first[j] == -1:
-                    first[j] = i
+            first = _first_row_per_order(enc, n_orders)
             per_order_sc = sc_np[first]
-            # map channel -> profile
             prof = profile_lut[np.clip(per_order_sc.astype(np.int64), 0, profile_lut.shape[0] - 1)]
 
             per_order_time = np.empty(n_orders, dtype=np.int16)
@@ -392,79 +411,84 @@ def _ensure_time_key_on_lines(table: pa.Table, *, seed: int) -> pa.Table:
             per_order = rng.integers(0, 1440, size=n_orders, dtype=np.int32).astype(np.int16, copy=False)
             per_order_arr = pa.array(per_order, type=pa.int16())
             time_col = pc.take(per_order_arr, enc.indices)
+
+        return table.append_column("TimeKey", time_col)
+
+    # No SalesOrderNumber: leave existing TimeKey alone; otherwise sample per row
+    if "TimeKey" in table.column_names:
+        return table
+
+    if has_channel:
+        sc_col = table["SalesChannelKey"]
+        if isinstance(sc_col, pa.ChunkedArray):
+            sc_col = sc_col.combine_chunks()
+        sc_np = np.asarray(sc_col.to_numpy(zero_copy_only=False), dtype=np.int16)
+        prof = profile_lut[np.clip(sc_np.astype(np.int64), 0, profile_lut.shape[0] - 1)]
+        out = np.empty(table.num_rows, dtype=np.int16)
+
+        m0 = prof == 0
+        if m0.any():
+            out[m0] = _sample_hour_weighted_minute(rng, int(m0.sum()), _RETAIL_HOUR_W)
+        m1 = prof == 1
+        if m1.any():
+            out[m1] = _sample_hour_weighted_minute(rng, int(m1.sum()), _DIGITAL_HOUR_W)
+        m2 = prof == 2
+        if m2.any():
+            out[m2] = _sample_hour_weighted_minute(rng, int(m2.sum()), _BUSINESS_HOUR_W)
+        m3 = prof == 3
+        if m3.any():
+            out[m3] = _sample_hour_weighted_minute(rng, int(m3.sum()), _ASSISTED_HOUR_W)
+
+        time_col = pa.array(out, type=pa.int16())
     else:
-        if has_channel:
-            sc_col = table["SalesChannelKey"]
-            if isinstance(sc_col, pa.ChunkedArray):
-                sc_col = sc_col.combine_chunks()
-            sc_np = np.asarray(sc_col.to_numpy(zero_copy_only=False), dtype=np.int16)
-            prof = profile_lut[np.clip(sc_np.astype(np.int64), 0, profile_lut.shape[0] - 1)]
-            out = np.empty(table.num_rows, dtype=np.int16)
-
-            m0 = prof == 0
-            if m0.any():
-                out[m0] = _sample_hour_weighted_minute(rng, int(m0.sum()), _RETAIL_HOUR_W)
-            m1 = prof == 1
-            if m1.any():
-                out[m1] = _sample_hour_weighted_minute(rng, int(m1.sum()), _DIGITAL_HOUR_W)
-            m2 = prof == 2
-            if m2.any():
-                out[m2] = _sample_hour_weighted_minute(rng, int(m2.sum()), _BUSINESS_HOUR_W)
-            m3 = prof == 3
-            if m3.any():
-                out[m3] = _sample_hour_weighted_minute(rng, int(m3.sum()), _ASSISTED_HOUR_W)
-
-            time_col = pa.array(out, type=pa.int16())
-        else:
-            per_row = rng.integers(0, 1440, size=table.num_rows, dtype=np.int32).astype(np.int16, copy=False)
-            time_col = pa.array(per_row, type=pa.int16())
+        per_row = rng.integers(0, 1440, size=table.num_rows, dtype=np.int32).astype(np.int16, copy=False)
+        time_col = pa.array(per_row, type=pa.int16())
 
     return table.append_column("TimeKey", time_col)
 
 
 def build_header_from_detail(detail: pa.Table) -> pa.Table:
+    import pyarrow.compute as pc
+
     gb = detail.group_by(["SalesOrderNumber"])
 
-    # Aggregate MIN+MAX for invariants we expect to be constant within an order
-    aggs = [
-        ("CustomerKey", "min"), ("CustomerKey", "max"),
-        ("StoreKey", "min"), ("StoreKey", "max"),
-        ("SalesPersonEmployeeKey", "min"), ("SalesPersonEmployeeKey", "max"),
-        ("OrderDate", "min"), ("OrderDate", "max"),
-        ("IsOrderDelayed", "max"),
-    ]
+    # Invariants expected to be constant within a SalesOrderNumber
+    inv_cols = ["CustomerKey", "StoreKey", "SalesPersonEmployeeKey", "OrderDate"]
     if "SalesChannelKey" in detail.column_names:
-        aggs += [("SalesChannelKey", "min"), ("SalesChannelKey", "max")]
+        inv_cols.append("SalesChannelKey")
     if "TimeKey" in detail.column_names:
-        aggs += [("TimeKey", "min"), ("TimeKey", "max")]
+        inv_cols.append("TimeKey")
+
+    # Aggregate MIN+MAX for invariants, plus max for IsOrderDelayed
+    aggs = []
+    for c in inv_cols:
+        aggs.append((c, "min"))
+        aggs.append((c, "max"))
+    aggs.append(("IsOrderDelayed", "max"))
 
     out = gb.aggregate(aggs)
 
-    # Validate invariants: for each order, min == max for constant fields
-    bad = pc.not_equal(out["CustomerKey_min"], out["CustomerKey_max"])
-    bad = pc.or_(bad, pc.not_equal(out["StoreKey_min"], out["StoreKey_max"]))
-    bad = pc.or_(bad, pc.not_equal(out["SalesPersonEmployeeKey_min"], out["SalesPersonEmployeeKey_max"]))
-    bad = pc.or_(bad, pc.not_equal(out["OrderDate_min"], out["OrderDate_max"]))
+    # Build boolean mask of any invariant mismatch
+    bad = None
+    for c in inv_cols:
+        neq = pc.not_equal(out[f"{c}_min"], out[f"{c}_max"])
+        bad = neq if bad is None else pc.or_(bad, neq)
 
-    if "SalesChannelKey_min" in out.column_names:
-        bad = pc.or_(bad, pc.not_equal(out["SalesChannelKey_min"], out["SalesChannelKey_max"]))
-    if "TimeKey_min" in out.column_names:
-        bad = pc.or_(bad, pc.not_equal(out["TimeKey_min"], out["TimeKey_max"]))
+    if bad is not None and bool(pc.any(bad).as_py()):
+        bad_out = out.filter(bad).slice(0, 5)
 
-    if bool(pc.any(bad).as_py()):
-        bad_idx = pc.indices_nonzero(bad)
-        # take first few offenders for error message
-        k = min(5, bad_idx.length())
-        take_idx = bad_idx.slice(0, k)
+        def _py(name: str):
+            return bad_out[name].to_pylist() if name in bad_out.column_names else None
 
-        so = pc.take(out["SalesOrderNumber"], take_idx).to_pylist()
-        ck_min = pc.take(out["CustomerKey_min"], take_idx).to_pylist()
-        ck_max = pc.take(out["CustomerKey_max"], take_idx).to_pylist()
+        parts = [f"SalesOrderNumber(s)={_py('SalesOrderNumber')}"]
+        for c in inv_cols:
+            parts.append(f"{c}_min={_py(f'{c}_min')}")
+            parts.append(f"{c}_max={_py(f'{c}_max')}")
 
         raise RuntimeError(
-            "Invalid SalesOrderNumber invariants: a SalesOrderNumber maps to multiple values "
-            f"(example SalesOrderNumber(s)={so}, CustomerKey_min={ck_min}, CustomerKey_max={ck_max}). "
-            "This indicates overlapping order-id ranges across chunks OR duplicated/misaligned rows during order expansion."
+            "Invalid SalesOrderNumber invariants: a SalesOrderNumber maps to multiple values. "
+            + " | ".join(parts)
+            + " | This indicates overlapping order-id ranges across chunks OR duplicated/misaligned rows during order expansion."
         )
 
     # Build final header columns (use *_min for constant fields, max for IsOrderDelayed)
@@ -500,6 +524,13 @@ def _worker_task(args):
     for idx, batch_size, seed in tasks:
         idx_i = int(idx)
         batch_i = int(batch_size)
+
+        # hard guard: stride must be >= max batch size for the run
+        if cap_orders < batch_i:
+            raise RuntimeError(
+                f"State.chunk_size={cap_orders} < batch_i={batch_i}; "
+                "chunk_size must be the constant order-id stride and >= the maximum batch size."
+            )
 
         chunk_seed = derive_chunk_seed(seed, idx_i, stride=10_000)
 


### PR DESCRIPTION
## Summary
This PR fixes duplicate SalesOrderNumber generation and makes SalesOrderLineNumber per SalesOrderNumber configurable via `sales.max_lines_per_order`.

## What changed
- Ensures SalesOrderNumber uniqueness by binding stable per-run order ID inputs in worker globals (stride/run-id) so multiprocessing cannot collide.
- Adds/threads `sales.max_lines_per_order` from `config.yaml` through the sales runner into worker init and sales_logic State.
- Enforces `max_lines_per_order >= 1` and caps generated SalesOrderDetail line numbering accordingly.
- Keeps `sales_output` modes and returns generation compatible with required order columns.

## How to verify
After generation/import, run:

```sql
-- 1) No duplicate SalesOrderNumber
SELECT SalesOrderNumber, COUNT(*) AS Cnt
FROM dbo.SalesOrderHeader
GROUP BY SalesOrderNumber
HAVING COUNT(*) > 1;

-- 2) Max line number respects cap
SELECT TOP (20)
  SalesOrderNumber,
  MAX(SalesOrderLineNumber) AS MaxLine
FROM dbo.SalesOrderDetail
GROUP BY SalesOrderNumber
ORDER BY MaxLine DESC;
```
Closes #66 